### PR TITLE
Added MobileBarcodeScanner constructor for Storyboarding MonoTouch devs

### DIFF
--- a/src/ZXing.Net.Mobile/MonoTouch/MobileBarcodeScanner.cs
+++ b/src/ZXing.Net.Mobile/MonoTouch/MobileBarcodeScanner.cs
@@ -11,6 +11,11 @@ namespace ZXing.Mobile
 		ZxingCameraViewController viewController;
 		UIViewController appController;
 
+		public MobileBarcodeScanner (object delegateController)
+		{
+			appController = (UIViewController)delegatecontroller;
+		}
+
 		public MobileBarcodeScanner ()
 		{
 			foreach (var window in UIApplication.SharedApplication.Windows)


### PR DESCRIPTION
I added a MobileBarcodeScanner(object delegateController) constructor
to enable developers to pass along a UIViewController that will
function as the delegate for the scanner. This is handy when you, for
instance, are using a Storyboard and cannot set the
window.RootViewController because this is loaded from the Storyboard in
execution time.
