### PR TITLE
Fix compilation error caused by bad variable name in the MobileBarcodeScanner constructor.

### DIFF
--- a/src/ZXing.Net.Mobile/MonoTouch/MobileBarcodeScanner.cs
+++ b/src/ZXing.Net.Mobile/MonoTouch/MobileBarcodeScanner.cs
@@ -13,7 +13,7 @@ namespace ZXing.Mobile
 
 		public MobileBarcodeScanner (object delegateController)
 		{
-			appController = (UIViewController)delegatecontroller;
+			appController = (UIViewController)delegateController;
 		}
 
 		public MobileBarcodeScanner ()


### PR DESCRIPTION
Case mismatch when using the delegateController parameter inside the constructor.
Project will not build unless corrected.
