### PR TITLE
Updated MonoTouch/ZXingScannerView.cs

### DIFF
--- a/src/ZXing.Net.Mobile/MonoTouch/ZXingScannerView.cs
+++ b/src/ZXing.Net.Mobile/MonoTouch/ZXingScannerView.cs
@@ -85,14 +85,17 @@ namespace ZXing.Mobile
 				return false;
 			}
 
-			NSError err = null;
-			if (captureDevice.LockForConfiguration(out err))
+			if (captureDevice.IsFocusModeSupported(AVCaptureFocusMode.ModeContinuousAutoFocus))
 			{
-				captureDevice.FocusMode = AVCaptureFocusMode.ModeContinuousAutoFocus;
-				captureDevice.UnlockForConfiguration();
+				NSError err = null;
+				if (captureDevice.LockForConfiguration(out err))
+				{
+					captureDevice.FocusMode = AVCaptureFocusMode.ModeContinuousAutoFocus;
+					captureDevice.UnlockForConfiguration();
+				}
+				else
+					Console.WriteLine("Failed to Lock for Config: " + err.Description);
 			}
-			else
-				Console.WriteLine("Failed to Lock for Config: " + err.Description);
 
 			var input = AVCaptureDeviceInput.FromDevice (captureDevice);
 			if (input == null){


### PR DESCRIPTION
Updated SetupCaptureSession to validate that the device supports Continuous Auto Focus mode before setting it.  This was causing an app to crash on devices that do not support it, specifically an iPod Touch 4th generation device.
