### PR TITLE
fix sample not work in ios earlier 6.0

### DIFF
--- a/samples/MonoTouch/MonoTouch.Sample/Info.plist
+++ b/samples/MonoTouch/MonoTouch.Sample/Info.plist
@@ -16,5 +16,7 @@
 	</array>
 	<key>CFBundleDisplayName</key>
 	<string>ZXing Sample</string>
+	<key>MinimumOSVersion</key>
+	<string>5.0</string>
 </dict>
 </plist>

--- a/src/ZXing.Net.Mobile/MonoTouch/ZXingScannerView.cs
+++ b/src/ZXing.Net.Mobile/MonoTouch/ZXingScannerView.cs
@@ -12,6 +12,7 @@ using ZXing.Common;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading;
+using MonoTouch.ObjCRuntime;
 
 namespace ZXing.Mobile
 {
@@ -96,8 +97,11 @@ namespace ZXing.Mobile
 
 			previewLayer = new AVCaptureVideoPreviewLayer(session);
 
-			//Framerate set here (15 fps)
-			previewLayer.Connection.VideoMinFrameDuration = new CMTime(1, 10);
+			if(previewLayer.RespondsToSelector(new Selector("connection")))
+			{
+				//Framerate set here (15 fps)
+				previewLayer.Connection.VideoMinFrameDuration = new CMTime(1, 10);
+			}
 			previewLayer.LayerVideoGravity = AVLayerVideoGravity.ResizeAspectFill;
 			previewLayer.Frame = this.Frame;
 			previewLayer.Position = new PointF(this.Layer.Bounds.Width / 2, (this.Layer.Bounds.Height / 2));
@@ -225,20 +229,23 @@ namespace ZXing.Mobile
 		{
 			previewLayer.Frame = this.Frame;
 
-			switch (orientation)
+			if(previewLayer.RespondsToSelector(new Selector("connection")))
 			{
-				case UIInterfaceOrientation.LandscapeLeft:
-					previewLayer.Connection.VideoOrientation = AVCaptureVideoOrientation.LandscapeLeft;
-					break;
-				case UIInterfaceOrientation.LandscapeRight:
-					previewLayer.Connection.VideoOrientation = AVCaptureVideoOrientation.LandscapeRight;
-					break;
-				case UIInterfaceOrientation.Portrait:
-					previewLayer.Connection.VideoOrientation = AVCaptureVideoOrientation.Portrait;
-					break;
-				case UIInterfaceOrientation.PortraitUpsideDown:
-					previewLayer.Connection.VideoOrientation = AVCaptureVideoOrientation.PortraitUpsideDown;
-					break;
+				switch (orientation)
+				{
+					case UIInterfaceOrientation.LandscapeLeft:
+						previewLayer.Connection.VideoOrientation = AVCaptureVideoOrientation.LandscapeLeft;
+						break;
+					case UIInterfaceOrientation.LandscapeRight:
+						previewLayer.Connection.VideoOrientation = AVCaptureVideoOrientation.LandscapeRight;
+						break;
+					case UIInterfaceOrientation.Portrait:
+						previewLayer.Connection.VideoOrientation = AVCaptureVideoOrientation.Portrait;
+						break;
+					case UIInterfaceOrientation.PortraitUpsideDown:
+						previewLayer.Connection.VideoOrientation = AVCaptureVideoOrientation.PortraitUpsideDown;
+						break;
+				}
 			}
 		}
 


### PR DESCRIPTION
fix crash on ios earlier 6.0. Before use connection property we should check is it available or not
