### PR TITLE
Fix comparison in MonoTouch sample

### DIFF
--- a/src/ZXing.Net.Mobile/MonoTouch/ZXingScannerView.cs
+++ b/src/ZXing.Net.Mobile/MonoTouch/ZXingScannerView.cs
@@ -110,7 +110,7 @@ namespace ZXing.Mobile
 				    device.Position == AVCaptureDevicePosition.Front)
 
 					break; //Front camera successfully set
-				else if (device.Position = AVCaptureDevicePosition.Back && (!options.UseFrontCameraIfAvailable.HasValue || !options.UseFrontCameraIfAvailable.Value))
+				else if (device.Position == AVCaptureDevicePosition.Back && (!options.UseFrontCameraIfAvailable.HasValue || !options.UseFrontCameraIfAvailable.Value))
 					break; //Back camera succesfully set
 			}
 			if (captureDevice == null){


### PR DESCRIPTION
Single '=' used in comparison in MonoTouch sample.
