### PR TITLE
Added Google Glass workaround for the camera on Android

### DIFF
--- a/src/ZXing.Net.Mobile/Android/ZXingSurfaceView.cs
+++ b/src/ZXing.Net.Mobile/Android/ZXingSurfaceView.cs
@@ -118,7 +118,11 @@ namespace ZXing.Mobile
 			
 			var parameters = camera.GetParameters ();
 			parameters.PreviewFormat = ImageFormatType.Nv21;
-			
+			// Google Glass requires this fix to display the camera output correctly
+			if (Build.Model.Contains ("Glass")) {
+				parameters.SetPreviewFpsRange (30000, 30000);
+				parameters.SetPreviewSize (640, 360);
+			}
 			camera.SetParameters (parameters);
 
 			SetCameraDisplayOrientation (this.activity);


### PR DESCRIPTION
Required fix to allow the camera to display correctly on Google Glass, added in a check for "Glass" so the parameters are only changed for the Google Glass.
