### PR TITLE
Allow android client code to customize preview size.

### DIFF
--- a/src/ZXing.Net.Mobile/Android/ZXingSurfaceView.cs
+++ b/src/ZXing.Net.Mobile/Android/ZXingSurfaceView.cs
@@ -143,6 +143,9 @@ namespace ZXing.Mobile
 				parameters.SetPreviewFpsRange (30000, 30000);
 				parameters.SetPreviewSize (640, 360);
 			}
+
+			SetPreviewSizePerOptions(parameters);
+
 			camera.SetParameters (parameters);
 
 			SetCameraDisplayOrientation (this.activity);
@@ -159,7 +162,6 @@ namespace ZXing.Mobile
 			ShutdownCamera ();
 		}
 
-
 		public byte[] rotateCounterClockwise(byte[] data, int width, int height)
 		{
 			var rotatedData = new byte[data.Length];
@@ -168,6 +170,23 @@ namespace ZXing.Mobile
 					rotatedData[x * height + height - y - 1] = data[x + y * width];
 			}
 			return rotatedData;
+		}
+
+		private void SetPreviewSizePerOptions (Android.Hardware.Camera.Parameters parameters)
+		{
+			if (options.PreviewSizeSelector == null)
+			{
+				return;
+			}
+			var choices = parameters.SupportedPreviewSizes
+				.Select(sz => new Dimension(sz.Width, sz.Height))
+				.ToList();
+			var selectedChoice = options.PreviewSizeSelector(choices);
+			if (selectedChoice == null)
+			{
+				return;
+			}
+			parameters.SetPreviewSize(selectedChoice.Width, selectedChoice.Height);
 		}
 		
 		DateTime lastPreviewAnalysis = DateTime.Now;

--- a/src/ZXing.Net.Mobile/Common/MobileBarcodeScanningOptions.cs
+++ b/src/ZXing.Net.Mobile/Common/MobileBarcodeScanningOptions.cs
@@ -26,6 +26,17 @@ namespace ZXing.Mobile
 		public int DelayBetweenAnalyzingFrames { get;set;}
 		public int InitialDelayBeforeAnalyzingFrames { get;set; }
 
+		/// <summary>
+		/// If a function is provided here, it is used to customize the preview
+		/// size of the camera. The function can return null to use the default.
+		/// </summary>
+		/// <remarks>
+		/// Selecting a lower preview size improves performance on some devices.
+		/// E.g., a 2013 Nexus 7 defaults to 1920 x 1080, the processing of which
+		/// seems to cause significant lag.
+		/// </remarks>
+		public Func<IList<Dimension>, Dimension> PreviewSizeSelector { get;set; }
+
 		public static MobileBarcodeScanningOptions Default
 		{
 			get { return new MobileBarcodeScanningOptions(); }


### PR DESCRIPTION
The bar code scanner was very slow on my 2013 Nexus 7. I suspected in might be image size when I loaded the same app on my Nexus 4 and it was really fast. The Nexus 7 was using a preview size of 1920x1080, and when I turned it down to 320 x something it still recognized bar codes fine but was way faster.

If you think this would be a good addition to the project, but don't care for the technique I used for exposing the option, let me know and I'll adjust it.