### PR TITLE
PDF417 Encoding fix

### DIFF
--- a/src/ZXing.Net/pdf417/encoder/PDF417HighLevelEncoder.cs
+++ b/src/ZXing.Net/pdf417/encoder/PDF417HighLevelEncoder.cs
@@ -168,7 +168,9 @@ namespace ZXing.PDF417.Internal
             // So we try here the some different ones
             DEFAULT_ENCODING = Encoding.GetEncoding(1252);
          }
-#elif !SILVERLIGHT || WINDOWS
+#elif MONOTOUCH
+		 DEFAULT_ENCODING = Encoding.GetEncoding("UTF-8");
+#elif !SILVERLIGHT || WINDOWS 
          DEFAULT_ENCODING = Encoding.GetEncoding("CP437");
 #else
          // Silverlight supports only UTF-8 and UTF-16 out-of-the-box


### PR DESCRIPTION
Fix default encoding for MonoTouch and PDF417 to be UTF-8
