### PR TITLE
WP: Catching HW focus exception

### DIFF
--- a/src/ZXing.Net.Mobile/WindowsPhone/SimpleCameraReader.cs
+++ b/src/ZXing.Net.Mobile/WindowsPhone/SimpleCameraReader.cs
@@ -161,7 +161,14 @@ namespace ZXing.Mobile
 
 					CameraButtons.ShutterKeyHalfPressed += (o, arg) =>
 					{
-						_photoCamera.Focus();
+						try
+						{
+							_photoCamera.Focus();
+						}
+						catch
+						{
+							// Do nothing
+						}
 					};
 
 					_timer.Start();


### PR DESCRIPTION
Catching exception when HW shutter key is pressed but _photoCamera doesn't exist anymore.