### PR TITLE
Issue #152 Resolution - Blackout the Video Brush prevents the random freezing

### DIFF
--- a/src/ZXing.Net.Mobile/WindowsPhone/ZXingScannerControl.xaml.cs
+++ b/src/ZXing.Net.Mobile/WindowsPhone/ZXingScannerControl.xaml.cs
@@ -95,10 +95,17 @@ namespace ZXing.Mobile
             if (UseCustomOverlay && CustomOverlay != null)
                 gridCustomOverlay.Children.Remove(CustomOverlay);
 
+            BlackoutVideoBrush();
+            
             _reader.Stop();
 			_reader = null;
         }
 
+        private void BlackoutVideoBrush()
+        {
+        	_previewVideo.SetSource(new MediaElement());
+        }
+        
         public void Cancel()
         {
             LastScanResult = null;


### PR DESCRIPTION
Freezing caused from random garbage collections purging the PhotoCamera while the VideoBrush is still using it. Thanks to http://stackoverflow.com/a/13481472 for the hint.