### PR TITLE
iOS 8 devices crashing if the screen rotates during a scan. 

### DIFF
--- a/src/ZXing.Net.Mobile/iOS/ZXingScannerView.cs
+++ b/src/ZXing.Net.Mobile/iOS/ZXingScannerView.cs
@@ -418,7 +418,7 @@ namespace ZXing.Mobile
 
 			previewLayer.Frame = new CGRect (0, 0, this.Frame.Width, this.Frame.Height);
 
-			if (previewLayer.RespondsToSelector (new Selector ("connection")))
+			if (previewLayer.RespondsToSelector (new Selector ("connection")) && previewLayer.Connection != null)
 			{
 				switch (orientation)
 				{


### PR DESCRIPTION
This was being caused by a null reference in the previewLayer.Connection. I didn't dive too deep into it so I just added a simple null check. A better solution might be to find out why it is being set to null when the screen rotates during a scan. 

Steps to reproduce:

1) Load sample.ios onto an ios 8 device
2) Select any of the scan options and let the camera be loaded
3) rotate the screen and do a scan