### PR TITLE
async release camera

### DIFF
--- a/src/ZXing.Net.Mobile/Android/ZXingSurfaceView.cs
+++ b/src/ZXing.Net.Mobile/Android/ZXingSurfaceView.cs
@@ -15,6 +15,7 @@ using Android.Graphics;
 using Android.Content.PM;
 using Android.Hardware;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace ZXing.Mobile
 {
@@ -33,6 +34,8 @@ namespace ZXing.Mobile
 		MobileBarcodeScanningOptions options;
 		Action<ZXing.Result> callback;
 		Activity activity;
+
+        private static ManualResetEventSlim _cameraLockEvent = new ManualResetEventSlim(true);
 
 		public ZXingSurfaceView (Activity activity, MobileBarcodeScanningOptions options, Action<ZXing.Result> callback)
 			: base (activity)
@@ -91,6 +94,8 @@ namespace ZXing.Mobile
 
 			try 
 			{
+                GetExclusiveAccess();
+
 				var version = Android.OS.Build.VERSION.SdkInt;
 
 				if (version >= BuildVersionCodes.Gingerbread)
@@ -492,24 +497,31 @@ namespace ZXing.Mobile
 			}
 		}
 		
-		
 		public void ShutdownCamera ()
 		{
 			tokenSource.Cancel();
-			
-			if (camera != null) {
-		                try {
-		                    camera.SetPreviewCallback(null);
-		                    camera.StopPreview();
-		                    camera.Release();
-		                }
-		                catch (Exception e) {
-		                    Android.Util.Log.Error("ZXing.Net.Mobile", e.ToString());
-		                }
-		                finally {
-		                    camera = null;
-		                }
-			}
+
+            if (camera == null)
+                return;
+
+            var theCamera = camera;
+            camera = null;
+
+            // make this asyncronous so that we can return from the view straight away instead of waiting for the camera to release.
+            Task.Factory.StartNew(() =>
+                {
+                    try {
+                        theCamera.SetPreviewCallback(null);
+                        theCamera.StopPreview();
+                        theCamera.Release();
+                    }
+                    catch (Exception e) {
+                        Android.Util.Log.Error("ZXing.Net.Mobile", e.ToString());
+                    }
+                    finally {
+                        ReleaseExclusiveAccess();
+                    }
+                });
 		}
 		
 		
@@ -566,6 +578,24 @@ namespace ZXing.Mobile
 			
 			return new Size(s.Width, s.Height);
 		}
+
+        private void GetExclusiveAccess()
+        {
+            Android.Util.Log.Debug("ZXing.Net.Mobile", "Getting Camera Exclusive access");
+            var result = _cameraLockEvent.Wait(TimeSpan.FromSeconds(30));
+            if (!result)
+                throw new Exception("Couldn't get exclusive access to the camera");
+
+            _cameraLockEvent.Reset();
+            Android.Util.Log.Debug("ZXing.Net.Mobile", "Got Camera Exclusive access");
+        }
+
+        private void ReleaseExclusiveAccess()
+        {
+            // release the camera exclusive access allowing it to be used again.
+            Android.Util.Log.Debug("ZXing.Net.Mobile", "Releasing Camera exclusive access");
+            _cameraLockEvent.Set();
+        }
 	}
 }
 


### PR DESCRIPTION
Releases the camera asynchronously when closing ZXingSurfaceView in
android.
Means the view can be dismissed quickly.

Locks the camera resource behind a manualresetevent so that reopening
the scanner view straight away will wait until the camera is ready again
before attempting to use it.