### PR TITLE
Readme: updated release notes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,22 +29,25 @@ buttonScan.Click += (sender, e) => {
 - Scanner as a View - UIView (iOS) / Fragment (Android) / Control (WP)
 
 ###Changes
+ - v1.4.7.1
+        - iOS: Updated Unified support
+
  - v1.4.7
-        - Updated ZXing.NET
+        - Updated ZXing.Net
         - iOS: Better destruction of default overlay to prevent memory leak
         - WP8: Fixed issue with HW shutter pressed after camera no longer available
         - Android: Fixed `Scan` method
 
  - v1.4.6
         - Android: Updated Android Support Library v4 component used (20.0.0.3)
-        - Updated ZXing.NET (SVN commit 88850)
+        - Updated ZXing.Net (SVN commit 88850)
         - Android: now takes `UseFrontCameraIfAvailable` into account ([#120](https://github.com/Redth/ZXing.Net.Mobile/issues/120))
         - Added camera resolution selector to MobileBarcodeScanningOptions
         - WP8: Fixed a null reference exception ([#104](https://github.com/Redth/ZXing.Net.Mobile/issues/104))
 
  - v1.4.5
         - Android: Updated Android Support Library v4 component used (20.0.0)
-        - Updated ZXing.NET
+        - Updated ZXing.Net
         - WP8: Fixed an issue with an exception on subsequent scans ([#102](https://github.com/Redth/ZXing.Net.Mobile/pull/102))
         - Android: Updated Android Support Library v4 component used (4.19.0.1)
 
@@ -59,7 +62,7 @@ buttonScan.Click += (sender, e) => {
         - Android: Scanner rotates as needed for orientation
         - Android: Removed YuvImage use for better, faster decoding with less memory usage
         - Android: Added permission checks
-        - Updated ZXing.NET version used
+        - Updated ZXing.Net version used
 
  - v1.4.2
  	- WP8: Fixed crash when pressing back while camera initializes

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,38 @@ buttonScan.Click += (sender, e) => {
 - Scanner as a View - UIView (iOS) / Fragment (Android) / Control (WP)
 
 ###Changes
+ - v1.4.7
+        - Updated ZXing.NET
+        - iOS: Better destruction of default overlay to prevent memory leak
+        - WP8: Fixed issue with HW shutter pressed after camera no longer available
+        - Android: Fixed `Scan` method
+
+ - v1.4.6
+        - Android: Updated Android Support Library v4 component used (20.0.0.3)
+        - Updated ZXing.NET (SVN commit 88850)
+        - Android: now takes `UseFrontCameraIfAvailable` into account ([#120](https://github.com/Redth/ZXing.Net.Mobile/issues/120))
+        - Added camera resolution selector to MobileBarcodeScanningOptions
+        - WP8: Fixed a null reference exception ([#104](https://github.com/Redth/ZXing.Net.Mobile/issues/104))
+
+ - v1.4.5
+        - Android: Updated Android Support Library v4 component used (20.0.0)
+        - Updated ZXing.NET
+        - WP8: Fixed an issue with an exception on subsequent scans ([#102](https://github.com/Redth/ZXing.Net.Mobile/pull/102))
+        - Android: Updated Android Support Library v4 component used (4.19.0.1)
+
+ - v1.4.4
+        - iOS: Fixed issue with loading view size in landscape orientation ([#100](https://github.com/Redth/ZXing.Net.Mobile/issues/100))
+        - Android: Fixed issue with scanning not working from timestamps ([#98](https://github.com/Redth/ZXing.Net.Mobile/issues/98))
+
+ - v1.4.3
+        - iOS: Fixed slowness after 4-5 scans ([#71](https://github.com/Redth/ZXing.Net.Mobile/issues/71))
+        - WP8: Fixed preview sometimes not starting
+        - Android: Fixed resuming fragment which closes
+        - Android: Scanner rotates as needed for orientation
+        - Android: Removed YuvImage use for better, faster decoding with less memory usage
+        - Android: Added permission checks
+        - Updated ZXing.NET version used
+
  - v1.4.2
  	- WP8: Fixed crash when pressing back while camera initializes
  	- Android: Added merged workaround from @chrisntr support for Google Glass	


### PR DESCRIPTION
I was trying to figure out if a few overlooked bugs my own projects could be resolved after recent ZXing.Net.Mobile package updates, so I was going through the commit history. As long as I was doing so, I tried to distill the commits since the v1.4.2 release into some change notes for anyone else interested in catching up as they update.

Versions are marked based on a mix of commits and release dates of NuGet packages, so it's possible for a few items to be off by a release.

Thanks for all the hard work making this library awesome.