### PR TITLE
Added scanner = null 

### DIFF
--- a/src/ZXing.Net.Mobile/Android/ZXingScannerFragment.cs
+++ b/src/ZXing.Net.Mobile/Android/ZXingScannerFragment.cs
@@ -69,6 +69,8 @@ namespace ZXing.Mobile
 
 			frame.RemoveView (scanner);
 
+			scanner = null;
+
 			if (!UseCustomOverlayView)
 				frame.RemoveView (zxingOverlay);
 			else if (CustomOverlayView != null)


### PR DESCRIPTION
"Added scanner = null when pausing so that scanning doesn't get started twice when resuming"

Hello! I had trouble resuming on Android because the scanner variable in ZXingScannerFragment kept its value when pausing, meaning that scan() was called twice and it failed with an 'unable to get exclusive access' error. I think I've solved this by setting scanner=null inside the onPause.

This is my first ever pull request - let me know if I'm doing it right :)

Cheers.