### PR TITLE
Always release exclusive lock

### DIFF
--- a/src/ZXing.Net.Mobile/Android/ZXingSurfaceView.cs
+++ b/src/ZXing.Net.Mobile/Android/ZXingSurfaceView.cs
@@ -395,9 +395,12 @@ namespace ZXing.Mobile
 		{
 			tokenSource.Cancel();
 			
-            if (camera == null)
-                return;
-
+			if (camera == null) 
+			{
+				ReleaseExclusiveAccess();
+				return;
+			}
+            
             var theCamera = camera;
             camera = null;
 


### PR DESCRIPTION
Previously, if a lock was acquired in StartScanning in ZXingSurfaceView, and an exception was thrown before camera was set we'd never release the lock in ShutdownCamera in ZXingSurfaceView. Any subsequent attempts to access the camera would crash the application. This PR makes sure we always ``Set()`` the ``ManualResetEventSlim``.