### PR TITLE
Fixes for Windows Phone version of the library

### DIFF
--- a/src/ZXing.Net.Mobile.WindowsPhone.sln
+++ b/src/ZXing.Net.Mobile.WindowsPhone.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZXing.Net.Mobile.WindowsPho
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZXing.Net.Mobile.WindowsPhone7.1", "ZXing.Net.Mobile\ZXing.Net.Mobile.WindowsPhone7.1.csproj", "{CD15825D-D4CC-4BC4-9163-9CFB460AF836}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "zxing.portable", "ZXing.Net\zxing.portable.csproj", "{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,18 @@ Global
 		{CD15825D-D4CC-4BC4-9163-9CFB460AF836}.Release|ARM.Build.0 = Release|ARM
 		{CD15825D-D4CC-4BC4-9163-9CFB460AF836}.Release|x86.ActiveCfg = Release|x86
 		{CD15825D-D4CC-4BC4-9163-9CFB460AF836}.Release|x86.Build.0 = Release|x86
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Debug|ARM.Build.0 = Debug|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Debug|x86.Build.0 = Debug|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Release|ARM.ActiveCfg = Release|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Release|ARM.Build.0 = Release|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Release|x86.ActiveCfg = Release|Any CPU
+		{24B441F2-CBE9-4405-9FD0-72EBCBEA0EC3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ZXing.Net.Mobile/WindowsPhone/ZXingScannerControl.xaml.cs
+++ b/src/ZXing.Net.Mobile/WindowsPhone/ZXingScannerControl.xaml.cs
@@ -82,7 +82,7 @@ namespace ZXing.Mobile
 
         public void Torch(bool on)
         {
-            _reader.FlashMode = FlashMode.On;
+            _reader.FlashMode = on == true ? FlashMode.On : FlashMode.Off;
         }
 
         public void ToggleTorch()


### PR DESCRIPTION
- Added project reference to solution so it can be correctly referenced by WP projects.
- Fixed issue with `ZXingScannerControl.Torch` - it was always turning the torch on disregarding the parameter passed.