### PR TITLE
correct page cycle

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsPhone/ScanPage.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsPhone/ScanPage.xaml.cs
@@ -128,7 +128,7 @@ namespace ZXing.Mobile
             
             scannerControl.StartScanning(HandleResult, ScanningOptions);
 
-            if (!isNewInstance && NavigationService.CanGoBack)
+            if (!isNewInstance && !isDeactivated && NavigationService.CanGoBack)
                 NavigationService.GoBack();
             
             isNewInstance = false;
@@ -136,12 +136,14 @@ namespace ZXing.Mobile
             base.OnNavigatedTo(e);
         }
 
-	    private bool isNewInstance = false;
+	private bool isNewInstance = false;
+	private bool isDeactivated = false;
 	    
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             try 
             {
+            	isDeactivated = e.NavigationMode != NavigationMode.Back;
                 OnRequestAutoFocus -= RequestAutoFocusHandler;
                 OnRequestTorch -= RequestTorchHandler;
                 OnRequestToggleTorch -= RequestToggleTorchHandler;

--- a/Source/ZXing.Net.Mobile.WindowsPhone/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsPhone/ZXingScannerControl.xaml.cs
@@ -144,6 +144,8 @@ namespace ZXing.Mobile
             if (_reader != null)
             {
                 _reader.Stop();
+                _reader.CameraInitialized -= ReaderOnCameraInitialized;
+		_reader.DecodingCompleted -= (o, r) => DisplayResult(r);
                 _reader = null;
             }
         }


### PR DESCRIPTION
fix crash on re-activate the scanning page (if the app was in dormant state)