### PR TITLE
Fix issue with ZxingActivity.OnResume() crashing when ZXing can't get…

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/ZxingActivity.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZxingActivity.cs
@@ -137,8 +137,15 @@ namespace ZXing.Mobile
         {
             base.OnResume ();
 
-            if (!waitingForPermission && canScan)
-                StartScanning ();
+            try
+            {
+                if (!waitingForPermission && canScan)
+                    StartScanning ();
+            }
+            catch (Exception ex) {
+                Android.Util.Log.Error (MobileBarcodeScanner.TAG, ex.ToString ());
+                Finish ();
+            }
         }
 
         public override void OnRequestPermissionsResult (int requestCode, string[] permissions, [GeneratedEnum] Permission[] grantResults)


### PR DESCRIPTION
… exclusive access to the camera. The exception cannot be caught from an app so it will crash instead of failing gracefully.

The Fix is to just catch the exception and log it to Android.Util.Log.Error, then finish the Activity.

Just a fixup of my previous pull request, as it included merges of my fork, so instead did a rebase to Redth/master.