### PR TITLE
Fix issue with ZXingScannerFragment when using a CustomOverlayView

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/ZXingScannerFragment.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingScannerFragment.cs
@@ -60,7 +60,10 @@ namespace ZXing.Mobile
                 var layoutParams = getChildLayoutParams();
                 // reattach scanner and overlay views.
                 frame.AddView(scanner, layoutParams);
-                frame.AddView(zxingOverlay, layoutParams);
+                if (!UseCustomOverlayView)
+                    frame.AddView(zxingOverlay, layoutParams);
+                else if (CustomOverlayView != null)
+                    frame.AddView(CustomOverlayView, layoutParams);
             }
         }
 


### PR DESCRIPTION
When calling OnStart(), the fragment tried to add the zxingOverlay which was null.  I reused the same if condition that is in OnStop().