### PR TITLE
Explicitly set ContinuousScanning = false in Scan() on WP

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsPhone/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.WindowsPhone/MobileBarcodeScanner.cs
@@ -71,6 +71,7 @@ namespace ZXing.Mobile
                 ScanPage.CustomOverlay = this.CustomOverlay;
                 ScanPage.TopText = TopText;
                 ScanPage.BottomText = BottomText;
+                ScanPage.ContinuousScanning = false;
 
                 Dispatcher.BeginInvoke(() =>
 				{


### PR DESCRIPTION
For single scan on Windows Phone, set ScanPage.ContinuousScanning = false explicitly so that Scan() can be
used after ScanContinuously().  Otherwise the overlay will not close
automatically after Scan() exits even if you create a new instance of scanner.

Tested and solves issue on Lumia 640.