### PR TITLE
ZXingScannerControl.xaml.cs : StopScanningAsync() dispatching.

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -13,6 +13,7 @@ using Windows.Media;
 using Windows.Media.Capture;
 using Windows.Media.MediaProperties;
 using Windows.System.Display;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -231,7 +232,7 @@ namespace ZXing.Mobile
                     if (!ContinuousScanning)
                     {
                         delay = Timeout.Infinite;
-                        await StopScanningAsync();
+                        await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => { await StopScanningAsync(); });
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #283 .

This fixes crash, caused by [displayInformation.OrientationChanged] unsubscribing from non-UI thread.

BTW: other way to fix the crash is just to remove the StopScanningAsync() calling at all: in the sample it will be called during [OnNavigatingFrom] handling. But this may cause other issues.