### PR TITLE
Xamarin Forms Binding Support

### DIFF
--- a/Source/ZXing.Net.Mobile.Forms/ZXingBarcodeImageView.cs
+++ b/Source/ZXing.Net.Mobile.Forms/ZXingBarcodeImageView.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using ZXing.Common;
 
 namespace ZXing.Net.Mobile.Forms
@@ -12,10 +11,9 @@ namespace ZXing.Net.Mobile.Forms
         }
 
         public static readonly BindableProperty BarcodeFormatProperty =
-            BindableProperty.Create<ZXingBarcodeImageView, BarcodeFormat> (
-                p => p.BarcodeFormat,
+            BindableProperty.Create( nameof( BarcodeFormat ), typeof( BarcodeFormat ), typeof( ZXingBarcodeImageView ), 
                 defaultValue: BarcodeFormat.QR_CODE, 
-                defaultBindingMode: BindingMode.TwoWay);
+                defaultBindingMode: BindingMode.TwoWay );
         
         public BarcodeFormat BarcodeFormat {
             get { return (BarcodeFormat)GetValue (BarcodeFormatProperty); }
@@ -24,8 +22,7 @@ namespace ZXing.Net.Mobile.Forms
 
 
         public static readonly BindableProperty BarcodeValueProperty =
-            BindableProperty.Create<ZXingBarcodeImageView, string> (
-                p => p.BarcodeValue, 
+            BindableProperty.Create( nameof(BarcodeValue), typeof(string), typeof(ZXingBarcodeImageView),
                 defaultValue: string.Empty, 
                 defaultBindingMode: BindingMode.TwoWay);
         
@@ -36,8 +33,7 @@ namespace ZXing.Net.Mobile.Forms
 
 
         public static readonly BindableProperty BarcodeOptionsProperty =
-            BindableProperty.Create<ZXingBarcodeImageView, EncodingOptions> (
-                p => p.BarcodeOptions, 
+            BindableProperty.Create( nameof(BarcodeOptions), typeof(EncodingOptions), typeof(ZXingBarcodeImageView),
                 defaultValue: new EncodingOptions (), 
                 defaultBindingMode: BindingMode.TwoWay);
 

--- a/Source/ZXing.Net.Mobile.Forms/ZXingDefaultOverlay.cs
+++ b/Source/ZXing.Net.Mobile.Forms/ZXingDefaultOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows.Input;
 using Xamarin.Forms;
 
 namespace ZXing.Net.Mobile.Forms
@@ -50,6 +51,7 @@ namespace ZXing.Net.Mobile.Forms
                 HorizontalOptions = LayoutOptions.Center,
                 TextColor = Color.White
             };
+            topText.SetBinding( Label.TextProperty, new Binding( nameof( TopText ) ) );
             Children.Add (topText, 0, 0);
 
             botText = new Label {
@@ -57,6 +59,7 @@ namespace ZXing.Net.Mobile.Forms
                 HorizontalOptions = LayoutOptions.Center,
                 TextColor = Color.White
             };
+            botText.SetBinding( Label.TextProperty, new Binding( nameof( BottomText ) ) );
             Children.Add (botText, 0, 2);
 
             flash = new Button {
@@ -64,27 +67,54 @@ namespace ZXing.Net.Mobile.Forms
                 VerticalOptions = LayoutOptions.Start,
                 Text = "Flash",
                 TextColor = Color.White,
-                IsVisible = false
             };
+            flash.SetBinding( Button.IsVisibleProperty, new Binding( nameof( ShowFlashButton ) ) );
             flash.Clicked += (sender, e) => {
-                var h = FlashButtonClicked;
-                if (h != null)
-                    h(flash, e);
+                FlashButtonClicked?.Invoke( flash, e );
             };
 
             Children.Add (flash, 0, 0);
         }
 
-        public string TopText {  get { return topText.Text; } set { topText.Text = value; } }
-        public string BottomText {  get { return botText.Text; } set { botText.Text = value; } }
+        public static readonly BindableProperty TopTextProperty =
+            BindableProperty.Create( nameof( TopText ), typeof( string ), typeof( ZXingDefaultOverlay ), string.Empty );
+        public string TopText
+        {
+            get { return ( string )GetValue( TopTextProperty ); }
+            set { SetValue( TopTextProperty, value ); }
+        }
 
-        public bool ShowFlashButton { 
-            get { 
-                return flash.IsVisible;
-            }
-            set { 
-                flash.IsVisible = value;
-            }
+        public static readonly BindableProperty BottomTextProperty =
+            BindableProperty.Create( nameof( BottomText ), typeof( string ), typeof( ZXingDefaultOverlay ), string.Empty );
+        public string BottomText
+        {
+            get { return ( string )GetValue( BottomTextProperty ); }
+            set { SetValue( BottomTextProperty, value ); }
+        }
+
+        public static readonly BindableProperty ShowFlashButtonProperty =
+            BindableProperty.Create( nameof( ShowFlashButton ), typeof( bool ), typeof( ZXingDefaultOverlay ), false );
+        public bool ShowFlashButton
+        { 
+            get { return ( bool )GetValue( ShowFlashButtonProperty ); }
+            set { SetValue( ShowFlashButtonProperty, value ); }
+        }
+
+        public static BindableProperty FlashCommandProperty = 
+            BindableProperty.Create( nameof( FlashCommand ), typeof( ICommand ), typeof( ZXingDefaultOverlay ), 
+                defaultValue: default(ICommand), 
+                propertyChanged: OnFlashCommandChanged );
+        public ICommand FlashCommand
+        {
+            get { return (ICommand)GetValue( FlashCommandProperty ); }
+            set { SetValue( FlashCommandProperty, value ); }
+        }
+
+        private static void OnFlashCommandChanged( BindableObject bindable, object oldvalue, object newValue )
+        {
+            var overlay = bindable as ZXingDefaultOverlay;
+            if( overlay?.flash == null ) return;
+            overlay.flash.Command = newValue as Command;
         }
     }
 }

--- a/Source/ZXing.Net.Mobile.Forms/ZXingScannerPage.cs
+++ b/Source/ZXing.Net.Mobile.Forms/ZXingScannerPage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using ZXing.Mobile;
 
 namespace ZXing.Net.Mobile.Forms
@@ -18,22 +17,32 @@ namespace ZXing.Net.Mobile.Forms
                 Options = options
             };
 
+            zxing.SetBinding( ZXingScannerView.IsTorchOnProperty, new Binding( nameof( IsTorchOn ) ) );
+            zxing.SetBinding( ZXingScannerView.IsAnalyzingProperty, new Binding( nameof( IsAnalyzing ) ) );
+            zxing.SetBinding( ZXingScannerView.IsScanningProperty, new Binding( nameof( IsScanning ) ) );
+            zxing.SetBinding( ZXingScannerView.HasTorchProperty, new Binding( nameof( HasTorch ) ) );
+            zxing.SetBinding( ZXingScannerView.ResultProperty, new Binding( nameof( Result ) ) );
+
             zxing.OnScanResult += (result) => {
-                var eh = this.OnScanResult;
-                if (eh != null)
-                    eh(result);
-                    //Device.BeginInvokeOnMainThread (() => eh (result));
+                this.OnScanResult?.Invoke( result );
+                //Device.BeginInvokeOnMainThread (() => eh (result));
             };
 
             if (customOverlay == null) {
-                defaultOverlay = new ZXingDefaultOverlay {
-                    TopText = "Hold your phone up to the barcode",
-                    BottomText = "Scanning will happen automatically",
-                    ShowFlashButton = zxing.HasTorch,
-                };
+                defaultOverlay = new ZXingDefaultOverlay();
+
+                defaultOverlay.SetBinding( ZXingDefaultOverlay.TopTextProperty, new Binding( nameof( DefaultOverlayTopText ) ) );
+                defaultOverlay.SetBinding( ZXingDefaultOverlay.BottomTextProperty, new Binding( nameof( DefaultOverlayBottomText ) ) );
+                defaultOverlay.SetBinding( ZXingDefaultOverlay.ShowFlashButtonProperty, new Binding( nameof( DefaultOverlayShowFlashButton ) ) );
+
+                DefaultOverlayTopText = "Hold your phone up to the barcode";
+                DefaultOverlayBottomText = "Scanning will happen automatically";
+                DefaultOverlayShowFlashButton = HasTorch;
+
                 defaultOverlay.FlashButtonClicked += (sender, e) => {
                     zxing.IsTorchOn = !zxing.IsTorchOn;
                 };
+
                 Overlay = defaultOverlay;
             } else {
                 Overlay = customOverlay;
@@ -51,33 +60,33 @@ namespace ZXing.Net.Mobile.Forms
             Content = grid;
         }
 
-        public string DefaultOverlayTopText {
-            get {
-                return defaultOverlay == null ? string.Empty : defaultOverlay.TopText;
-            }
-            set {
-                if (defaultOverlay != null)
-                    defaultOverlay.TopText = value;
-            }
+        #region Default Overlay Properties
+
+        public static readonly BindableProperty DefaultOverlayTopTextProperty =
+            BindableProperty.Create( nameof( DefaultOverlayTopText ), typeof( string ), typeof( ZXingScannerPage ), string.Empty );
+        public string DefaultOverlayTopText
+        {
+            get { return ( string )GetValue( DefaultOverlayTopTextProperty ); }
+            set { SetValue( DefaultOverlayTopTextProperty, value ); }
         }
-        public string DefaultOverlayBottomText {
-            get {
-                return defaultOverlay == null ? string.Empty : defaultOverlay.BottomText;
-            }
-            set {
-                if (defaultOverlay != null)
-                    defaultOverlay.BottomText = value;
-            }
+
+        public static readonly BindableProperty DefaultOverlayBottomTextProperty =
+            BindableProperty.Create( nameof( DefaultOverlayBottomText ), typeof( string ), typeof( ZXingScannerPage ), string.Empty );
+        public string DefaultOverlayBottomText
+        {
+            get { return ( string )GetValue( DefaultOverlayBottomTextProperty ); }
+            set { SetValue( DefaultOverlayBottomTextProperty, value ); }
         }
-        public bool DefaultOverlayShowFlashButton {
-            get {
-                return defaultOverlay == null ? false : defaultOverlay.ShowFlashButton;
-            }
-            set {
-                if (defaultOverlay != null)
-                    defaultOverlay.ShowFlashButton = value;
-            }
+
+        public static readonly BindableProperty DefaultOverlayShowFlashButtonProperty =
+            BindableProperty.Create( nameof( DefaultOverlayShowFlashButton ), typeof( bool ), typeof( ZXingScannerPage ), false );
+        public bool DefaultOverlayShowFlashButton
+        {
+            get { return ( bool )GetValue( DefaultOverlayShowFlashButtonProperty ); }
+            set { SetValue( DefaultOverlayShowFlashButtonProperty, value ); }
         }
+
+        #endregion
 
         public delegate void ScanResultDelegate (ZXing.Result result);
         public event ScanResultDelegate OnScanResult;
@@ -86,6 +95,8 @@ namespace ZXing.Net.Mobile.Forms
             get;
             private set;
         }
+
+        #region Functions
 
         public void ToggleTorch ()
         {
@@ -131,43 +142,45 @@ namespace ZXing.Net.Mobile.Forms
                 zxing.AutoFocus (x, y);
         }
 
-        public bool IsTorchOn {
-            get {
-                return zxing == null ? false : zxing.IsTorchOn;
-            }
-            set {
-                if (zxing != null)
-                    zxing.IsTorchOn = value;
-            }
+        #endregion
+
+        public static readonly BindableProperty IsTorchOnProperty =
+            BindableProperty.Create( nameof( IsTorchOn ), typeof( bool ), typeof( ZXingScannerPage ), false );
+        public bool IsTorchOn
+        {
+            get { return ( bool )GetValue( IsTorchOnProperty ); }
+            set { SetValue( IsTorchOnProperty, value ); }
         }
 
-        public bool IsAnalyzing {
-            get {
-                return zxing == null ? false : zxing.IsAnalyzing;
-            }
-            set {
-                if (zxing != null)
-                    zxing.IsAnalyzing = value;
-            }
+        public static readonly BindableProperty IsAnalyzingProperty =
+            BindableProperty.Create( nameof( IsAnalyzing ), typeof( bool ), typeof( ZXingScannerPage ), false );
+        public bool IsAnalyzing
+        {
+            get { return ( bool )GetValue( IsAnalyzingProperty ); }
+            set { SetValue( IsAnalyzingProperty, value ); }
         }
 
+        public static readonly BindableProperty IsScanningProperty =
+            BindableProperty.Create( nameof( IsScanning ), typeof( bool ), typeof( ZXingScannerPage ), false );
         public bool IsScanning
         {
-            get
-            {
-                return zxing == null ? false : zxing.IsScanning;
-            }
-            set
-            {
-                if (zxing != null)
-                    zxing.IsScanning = value;
-            }
+            get { return ( bool )GetValue( IsScanningProperty ); }
+            set { SetValue( IsScanningProperty, value ); }
         }
 
+        public static readonly BindableProperty HasTorchProperty =
+            BindableProperty.Create( nameof( HasTorch ), typeof( bool ), typeof( ZXingScannerPage ), false );
         public bool HasTorch {
-            get {
-                return zxing == null ? false : zxing.HasTorch;
-            }
+            get { return ( bool )GetValue( HasTorchProperty ); }
+            set { SetValue( HasTorchProperty, value ); }
+        }
+
+        public static readonly BindableProperty ResultProperty =
+            BindableProperty.Create( nameof( Result ), typeof( Result ), typeof( ZXingScannerPage ), default( Result ) );
+        public Result Result
+        {
+            get { return ( Result )GetValue( ResultProperty ); }
+            set { SetValue( ResultProperty, value ); }
         }
     }
 }

--- a/Source/ZXing.Net.Mobile.Forms/ZXingScannerView.cs
+++ b/Source/ZXing.Net.Mobile.Forms/ZXingScannerView.cs
@@ -1,8 +1,7 @@
 ﻿using System;
+using System.Windows.Input;
 using Xamarin.Forms;
 using ZXing.Mobile;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace ZXing.Net.Mobile.Forms
 {
@@ -21,9 +20,9 @@ namespace ZXing.Net.Mobile.Forms
 
         public void RaiseScanResult (Result result)
         {
-            var e = this.OnScanResult;
-            if (e != null)
-                e (result);
+            Result = result;
+            OnScanResult?.Invoke( Result );
+            ScanResultCommand?.Execute( Result );
         }
 
 
@@ -43,9 +42,8 @@ namespace ZXing.Net.Mobile.Forms
         }
 
 
-        public static readonly BindableProperty OptionsProperty =
-            BindableProperty.Create<ZXingScannerView, MobileBarcodeScanningOptions> (
-                p => p.Options, MobileBarcodeScanningOptions.Default);
+        public static readonly BindableProperty OptionsProperty = 
+            BindableProperty.Create( nameof( Options ), typeof( MobileBarcodeScanningOptions ), typeof( ZXingScannerView ), MobileBarcodeScanningOptions.Default );
         
         public MobileBarcodeScanningOptions Options {
             get { return (MobileBarcodeScanningOptions)GetValue (OptionsProperty); }
@@ -53,7 +51,7 @@ namespace ZXing.Net.Mobile.Forms
         }
 
         public static readonly BindableProperty IsScanningProperty =
-            BindableProperty.Create<ZXingScannerView, bool> (p => p.IsScanning, false);
+            BindableProperty.Create( nameof( IsScanning ), typeof( bool ), typeof( ZXingScannerView ), false );
 
         public bool IsScanning {
             get { return (bool)GetValue (IsScanningProperty); }
@@ -61,26 +59,40 @@ namespace ZXing.Net.Mobile.Forms
         }
 
         public static readonly BindableProperty IsTorchOnProperty =
-            BindableProperty.Create<ZXingScannerView, bool> (p => p.IsTorchOn, false);
+            BindableProperty.Create( nameof( IsTorchOn ), typeof( bool ), typeof( ZXingScannerView ), false );
         public bool IsTorchOn {
             get { return (bool)GetValue (IsTorchOnProperty); }
             set { SetValue (IsTorchOnProperty, value); }                
         }
 
-
         public static readonly BindableProperty HasTorchProperty =
-            BindableProperty.Create<ZXingScannerView, bool> (p => p.HasTorch, false);
+            BindableProperty.Create( nameof( HasTorch ), typeof( bool ), typeof( ZXingScannerView ), false );
         public bool HasTorch {
             get { return (bool)GetValue (HasTorchProperty); }
         }
 
-
-        public static readonly BindableProperty IsAnalyzingProperty = 
-            BindableProperty.Create<ZXingScannerView, bool> (p => p.IsAnalyzing, false);
+        public static readonly BindableProperty IsAnalyzingProperty =
+            BindableProperty.Create( nameof( IsAnalyzing ), typeof( bool ), typeof( ZXingScannerView ), false );
 
         public bool IsAnalyzing {
             get { return (bool)GetValue (IsAnalyzingProperty); }
             set { SetValue (IsAnalyzingProperty, value); }
+        }
+
+        public static readonly BindableProperty ResultProperty =
+            BindableProperty.Create( nameof( Result ), typeof( Result ), typeof( ZXingScannerView ), default( Result ) );
+        public Result Result
+        {
+            get { return ( Result )GetValue( ResultProperty ); }
+            set { SetValue( ResultProperty, value ); }
+        }
+
+        public static readonly BindableProperty ScanResultCommandProperty =
+            BindableProperty.Create( nameof( ScanResultCommand ), typeof( ICommand ), typeof( ZXingScannerView ), default( ICommand ) );
+        public ICommand ScanResultCommand
+        {
+            get { return ( ICommand )GetValue( ScanResultCommandProperty ); }
+            set { SetValue( ScanResultCommandProperty, value ); }
         }
     }
 }


### PR DESCRIPTION
Updated existing Bindable Properties calling that were calling the deprecated Create method.
Added Bindings to existing properties.
Added Bindable Result Property.
Refractored event handlers.