### PR TITLE
Fixing bugs in ZXing.Net.Mobile - IOS version

### DIFF
--- a/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerView.cs
+++ b/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerView.cs
@@ -230,13 +230,21 @@ namespace ZXing.Mobile
 
 					var mdo = metaDataObjects.FirstOrDefault();
 
-					if (mdo == null)
-						return;
+				    if (mdo == null)
+				    {
+				        working = false;
+				        wasScanned = true;
+                        		return;
+                    		    }
 
 					var readableObj = mdo as AVMetadataMachineReadableCodeObject;
 
-					if (readableObj == null)
-						return;
+				    if (readableObj == null)
+				    {
+                                        working = false;
+                        		wasScanned = true;
+                        		return;
+                        	    }
 
                     wasScanned = true;
 

--- a/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerViewController.cs
+++ b/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerViewController.cs
@@ -172,7 +172,11 @@ namespace ZXing.Mobile
 		}	
 		public override bool ShouldAutorotate ()
 		{
-			return true;
+		    if (ScanningOptions.AutoRotate != null)
+		    {
+		        return (bool)ScanningOptions.AutoRotate;
+		    }
+		    return false;
 		}
 
 		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations ()

--- a/Source/ZXing.Net.Mobile.iOS/ZXingScannerViewController.cs
+++ b/Source/ZXing.Net.Mobile.iOS/ZXingScannerViewController.cs
@@ -177,7 +177,11 @@ namespace ZXing.Mobile
 		}	
 		public override bool ShouldAutorotate ()
 		{
-			return true;
+			if (ScanningOptions.AutoRotate != null)
+            		{
+                		return (bool)ScanningOptions.AutoRotate;
+            		}
+            		return false;
 		}
 
 		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations ()
@@ -188,7 +192,11 @@ namespace ZXing.Mobile
 		[Obsolete ("Deprecated in iOS6. Replace it with both GetSupportedInterfaceOrientations and PreferredInterfaceOrientationForPresentation")]
 		public override bool ShouldAutorotateToInterfaceOrientation (UIInterfaceOrientation toInterfaceOrientation)
 		{
-			return true;
+			if (ScanningOptions.AutoRotate != null)
+            		{
+                		return (bool)ScanningOptions.AutoRotate;
+            		}
+            		return false;
 		}
 
 		void HandleOnScannerSetupComplete ()


### PR DESCRIPTION
I have made the following changes: 

File: AVCaptureScannerView.cs
Issue: Scanner failed when it started first time (IOS version). Setting  working = false and wasScanned = true on SetupCaptureSession.

File: AVCaptureScannerViewController.cs
Issue: Adding check on ScanningOptions.AutoRotate option in ShouldAutorotate and method

File: ZXingScannerViewController.cs
Issue: Adding check on ScanningOptions.AutoRotate option in ShouldAutorotate and ShouldAutorotateToInterfaceOrientation methods

Note: I have sent 4 separate pull requests previously. Please ignore them. This is the correct pull request with all the fixes I would like to be merged in the master branch. thank you :-)
