### PR TITLE
Fix little bug, return original page. also Add cancel button feature for UWP

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsUniversal/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/MobileBarcodeScanner.cs
@@ -25,7 +25,12 @@ namespace ZXing.Mobile
         public override void ScanContinuously(MobileBarcodeScanningOptions options, Action<Result> scanHandler)
         {
             //Navigate: /ZxingSharp.WindowsPhone;component/Scan.xaml
-            var rootFrame = RootFrame ?? Window.Current.Content as Frame ?? ((FrameworkElement) Window.Current.Content).GetFirstChildOfType<Frame>();
+
+            // Too much problem on it, such like: can't return correctly after finish. So I decide use new frame.
+            //var rootFrame = RootFrame ?? Window.Current.Content as Frame ?? ((FrameworkElement) Window.Current.Content).GetFirstChildOfType<Frame>();
+
+            ScanPage.LastFrame = Window.Current.Content;
+            var rootFrame = RootFrame ?? (Window.Current.Content = new Frame()) as Frame;
             var dispatcher = Dispatcher ?? Window.Current.Dispatcher;
 
             ScanPage.ScanningOptions = options;
@@ -35,17 +40,23 @@ namespace ZXing.Mobile
             ScanPage.CustomOverlay = this.CustomOverlay;
             ScanPage.TopText = TopText;
             ScanPage.BottomText = BottomText;
+            ScanPage.CancelButtonText = CancelButtonText;
             ScanPage.ContinuousScanning = true;
             
             dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 rootFrame.Navigate(typeof(ScanPage));
             });
+
         }
 
         public override Task<Result> Scan(MobileBarcodeScanningOptions options)
         {
-            var rootFrame = RootFrame ?? Window.Current.Content as Frame ?? ((FrameworkElement) Window.Current.Content).GetFirstChildOfType<Frame>();
+            // Too much problem on it, such like: can't return correctly after finish. So I decide use new frame.
+            //var rootFrame = RootFrame ?? Window.Current.Content as Frame ?? ((FrameworkElement) Window.Current.Content).GetFirstChildOfType<Frame>();
+
+            ScanPage.LastFrame = Window.Current.Content;
+            var rootFrame = RootFrame ?? (Window.Current.Content = new Frame()) as Frame;
             var dispatcher = Dispatcher ?? Window.Current.Dispatcher;
 
             return Task.Factory.StartNew(new Func<Result>(() =>
@@ -65,6 +76,7 @@ namespace ZXing.Mobile
                 ScanPage.CustomOverlay = this.CustomOverlay;
                 ScanPage.TopText = TopText;
                 ScanPage.BottomText = BottomText;
+                ScanPage.CancelButtonText = CancelButtonText;
 
                 dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
@@ -72,6 +84,8 @@ namespace ZXing.Mobile
                 });
                 
                 scanResultResetEvent.WaitOne();
+
+               
 
                 return result;
             }));            

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ScanPage.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ScanPage.xaml.cs
@@ -36,7 +36,10 @@ namespace ZXing.Mobile
         public static MobileBarcodeScannerBase Scanner { get; set; }
         public static UIElement CustomOverlay { get; set; }
         public static string TopText { get; set; }
+
+        public static UIElement LastFrame { get; set; }
         public static string BottomText { get; set; }
+        public static string CancelButtonText { get; set; }
         public static bool UseCustomOverlay { get; set; }
         public static bool ContinuousScanning { get; set; }
 
@@ -148,6 +151,8 @@ namespace ZXing.Mobile
         {
             scannerControl.TopText = TopText;
             scannerControl.BottomText = BottomText;
+            scannerControl.CancelButtonText = CancelButtonText;
+
 
             scannerControl.CustomOverlay = CustomOverlay;
             scannerControl.UseCustomOverlay = UseCustomOverlay;
@@ -165,8 +170,12 @@ namespace ZXing.Mobile
 
             await scannerControl.StartScanningAsync(HandleResult, ScanningOptions);
 
-            if (!isNewInstance && Frame.CanGoBack)
-                Frame.GoBack();
+            // Too much problem on it in original way, So I decide use replace way
+            //if (!isNewInstance && Frame.CanGoBack)
+            //    Frame.GoBack();
+
+            if (!isNewInstance)
+                Window.Current.Content = LastFrame;
 
             isNewInstance = false;
 
@@ -212,8 +221,11 @@ namespace ZXing.Mobile
             {
                 Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
                {
-                   if (Frame.CanGoBack)
-                       Frame.GoBack();
+                   // Too much problem on it, So I decide use replace way
+                   //if (!isNewInstance && Frame.CanGoBack)
+                   //    Frame.GoBack();
+                   if (!isNewInstance)
+                    Window.Current.Content = LastFrame;
                });
                 
             }

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml
@@ -40,6 +40,7 @@
             <Border Grid.Row="0" Visibility="Collapsed" VerticalAlignment="Top" HorizontalAlignment="Right" Width="120" Height="80">
                 <Button x:Name="buttonToggleFlash" Click="buttonToggleFlash_Click">Flash</Button>
             </Border>
+
             <Border Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                 <TextBlock x:Name="topText" TextAlignment="Center" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"></TextBlock>
             </Border>
@@ -51,7 +52,14 @@
             <Rectangle Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Fill="Black" Opacity="0.3"></Rectangle>
 
             <Border Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                <TextBlock x:Name="bottomText" TextAlignment="Center" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"></TextBlock>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <TextBlock x:Name="bottomText" TextAlignment="Center" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"></TextBlock>
+                    <Button Grid.Row="1" x:Name="buttonBack" Visibility="Collapsed"  HorizontalAlignment="Center"  Click="buttonBack_Click" Foreground="White">Back</Button>
+                </Grid>
             </Border>
 
         </Grid>

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -96,6 +96,13 @@ namespace ZXing.Mobile
             topText.Text = TopText ?? string.Empty;
             bottomText.Text = BottomText ?? string.Empty;
 
+            // Show on the back(return) button when set the CancelButtonText
+            if (!string.IsNullOrEmpty(CancelButtonText))
+            {
+                buttonBack.Content = CancelButtonText;
+                buttonBack.Visibility = Visibility.Visible;
+            }
+
             if (UseCustomOverlay)
             {
                 gridCustomOverlay.Children.Clear();
@@ -289,6 +296,7 @@ namespace ZXing.Mobile
         public MobileBarcodeScannerBase Scanner { get; set; }
         public UIElement CustomOverlay { get; set; }
         public string TopText { get; set; }
+        public string CancelButtonText { get; set; }
         public string BottomText { get; set; }
         public bool UseCustomOverlay { get; set; }
         public bool ContinuousScanning { get; set; }
@@ -372,16 +380,27 @@ namespace ZXing.Mobile
             stopping = true;
             isAnalyzing = false;
 
+            
+
             try
             {
-                await mediaCapture.StopPreviewAsync();
+                // Avoid it stop preview more than once
+                if (null != mediaCapture)
+                    await mediaCapture.StopPreviewAsync();
+
                 if (UseCustomOverlay && CustomOverlay != null)
                     gridCustomOverlay.Children.Remove(CustomOverlay);
             }
             catch { }
             finally {
-                //second execution from sample will crash if the object is not properly disposed (always on mobile, sometimes on desktop)
-                 mediaCapture.Dispose();
+                // Avoid it stop preview more than once
+                if (null != mediaCapture)
+                {
+                    //second execution from sample will crash if the object is not properly disposed (always on mobile, sometimes on desktop)
+                    mediaCapture.Dispose();
+                    mediaCapture = null;
+                }
+               
             }
 
             //this solves a crash occuring when the user rotates the screen after the QR scanning is closed
@@ -429,6 +448,15 @@ namespace ZXing.Mobile
             ToggleTorch();
         }
 
+        /// <summary>
+        /// Button for cancel and return to last page(only invalid when set CancelButtonText property.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private async void buttonBack_Click(object sender, RoutedEventArgs e)
+        {
+            await Cancel();
+        }
 
         /// <summary>
         /// Gets the current orientation of the UI in relation to the device and applies a corrective rotation to the preview

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ The `Camera` permission should be automatically included for you in the `Android
 In your `AppDelegate`'s `FinishedLaunching (..)` implementation, call:
 
 ```csharp
-ZXing.Net.Mobile.Forms.Android.Platform.Init();
+ZXing.Net.Mobile.Forms.iOS.Platform.Init();
 ```
 
 
@@ -80,7 +80,7 @@ In your main `Page`'s constructor, you should add:
 ZXing.Net.Mobile.Forms.WindowsUniversal.ZXingScannerViewRenderer.Init();
 ```
 
-If you notice that finishing scanning or pressing the back button is causing your Page to jump back further than you'd like, or if you're having trouble updating the UI of a Page after scanning is completed, you may need to set `NavigationCacheMode="Enabled"` within your Page's XAML `<Page ... />` element.
+If you want to show the Return button, just use: `scan.CancelButtonText = "Return";`, There is will show a button for return to your original Page, Of course you could change the button text to anything.
 
 
 ###Features


### PR DESCRIPTION
Fix exception, fix return page problem. and add show cancel button
feature.


1.Fix when finish scan stop, the mediaCapture.stopPreview() will execute more than onece, then there is a excpetion problem.
2.Old UWP will always use the current mainWindow Frame, that cause a lot of problem, like can't return to the original page. So I create a new Frame and replace mainWindow.Content, after finish scan just restore the original mainWindow.Content. All fine, I test it on real phone.

Now you could remove the description about add on MainWindow on Home page, because you don't need it anymore:
`NavigationCacheMode="Enabled"`

3.I add a cancel button. But If you want to use it, just need to set the CancelButtonText. like:

 `var scanner = new ZXing.Mobile.MobileBarcodeScanner();
scanner.CancelButtonText = "Return";`

That will more helpful because you don't need to press Back button on the phone, and cause some trouble.