### PR TITLE
Improve auto-focus settings and focus areas

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.Android/MobileBarcodeScanner.cs
@@ -157,5 +157,22 @@ namespace ZXing.Mobile
 				return torch;
 			}
 		}
+
+        internal static void LogDebug (string format, params object [] args)
+        {
+            Android.Util.Log.Debug ("ZXING", format, args);
+        }
+        internal static void LogError (string format, params object [] args)
+        {
+            Android.Util.Log.Error ("ZXING", format, args);
+        }
+        internal static void LogInfo (string format, params object [] args)
+        {
+            Android.Util.Log.Info ("ZXING", format, args);
+        }
+        internal static void LogWarn (string format, params object [] args)
+        {
+            Android.Util.Log.Warn ("ZXING", format, args);
+        }
 	}
 }

--- a/Source/ZXing.Net.Mobile.Android/ZXingScannerFragment.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingScannerFragment.cs
@@ -113,7 +113,7 @@ namespace ZXing.Mobile
 
         public void AutoFocus(int x, int y)
 		{
-			scanner.AutoFocus();
+			scanner.AutoFocus(x, y);
 		}
 
         Action<Result> scanCallback;

--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -486,7 +486,14 @@ namespace ZXing.Mobile
 
             Camera.GetCameraInfo (cameraId, info);
 
-            int correctedDegrees = (360 + info.Orientation - degrees) % 360;
+            int correctedDegrees;
+            if (info.Facing == CameraFacing.Front) {
+                correctedDegrees = (info.Orientation + degrees) % 360;
+                correctedDegrees = (360 - correctedDegrees) % 360; // compensate the mirror
+            } else {
+                // back-facing
+                correctedDegrees = (info.Orientation - degrees + 360) % 360;
+            }
 
             return correctedDegrees;
         }

--- a/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
+++ b/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
@@ -105,7 +105,7 @@ namespace ZXing.Net.Mobile.Forms.Android
             var y = e.GetY ();
 
             if (zxingSurface != null) {
-                zxingSurface.AutoFocus ();
+                zxingSurface.AutoFocus ((int)x, (int)y);
                 System.Diagnostics.Debug.WriteLine ("Touch: x={0}, y={1}", x, y);
             }
             return base.OnTouchEvent (e);

--- a/Source/ZXing.Net.Mobile.Forms/ZXing.Net.Mobile.Forms.csproj
+++ b/Source/ZXing.Net.Mobile.Forms/ZXing.Net.Mobile.Forms.csproj
@@ -67,7 +67,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="..\..\Samples\Forms\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\Samples\Forms\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <Import Project="..\..\packages\Xamarin.Forms.2.3.0.107\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.0.107\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/bootstrapper.ps1
+++ b/bootstrapper.ps1
@@ -34,7 +34,7 @@ Param(
     [string]$Target = "Default",
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
-    [string]$Verbosity = "Verbose",
+    [string]$Verbosity = "Diagnostic",
     [switch]$Experimental,
     [Alias("DryRun","Noop")]
     [switch]$WhatIf,

--- a/build.cake
+++ b/build.cake
@@ -16,8 +16,7 @@ var TARGET = Argument ("t", Argument ("target", "Default"));
 // Build a semver string out of the preview if it's specified
 if (!string.IsNullOrEmpty (PREVIEW)) {
 	var sv = ParseSemVer (VERSION);
-	sv.Prerelease = PREVIEW;
-	NUGET_VERSION = sv.ToString ();
+	NUGET_VERSION = CreateSemVer (sv.Major, sv.Minor, sv.Patch, PREVIEW).ToString ();
 }
 
 var buildSpec = new BuildSpec {

--- a/build.cake
+++ b/build.cake
@@ -3,19 +3,21 @@
 #addin nuget:?package=Cake.XCode
 #addin nuget:?package=Cake.Xamarin
 #addin nuget:?package=Cake.Xamarin.Build
+#addin nuget:?package=Cake.SemVer
 #addin nuget:?package=Cake.FileHelpers
 #addin nuget:?package=Cake.MonoApiTools
 
 var PREVIEW = "beta";
-var VERSION = EnvironmentVariable ("APPVEYOR_BUILD_VERSION") ?? Argument("version", "2.0.0.9999");
+var VERSION = EnvironmentVariable ("APPVEYOR_BUILD_VERSION") ?? Argument("version", "2.1.9999");
 var NUGET_VERSION = VERSION;
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
 // Build a semver string out of the preview if it's specified
 if (!string.IsNullOrEmpty (PREVIEW)) {
-	var v = Version.Parse (VERSION);
-	NUGET_VERSION = string.Format ("{0}.{1}.{2}-{3}{4}", v.Major, v.Minor, v.Build, PREVIEW, v.Revision);
+	var sv = ParseSemVer (VERSION);
+	sv.Prerelease = PREVIEW;
+	NUGET_VERSION = sv.ToString ();
 }
 
 var buildSpec = new BuildSpec {

--- a/build.cake
+++ b/build.cake
@@ -102,3 +102,4 @@ Task ("clean").IsDependentOn ("clean-base").Does (() =>
 SetupXamarinBuildTasks (buildSpec, Tasks, Task);
 
 RunTarget (TARGET);
+


### PR DESCRIPTION
This greatly improves the auto-focusing on Android.

Previously, `camera.AutoFocus (..)` was called on a timer, which worked.... ok at best.

Now, the actual AutoFocus  mode is set on the camera if it's supported.

Additionally, Focus Areas are now supported when the user touches on the screen, the focus will go to that area of the screen.

Finally, the Preview FPS rate is intelligently selected to maximize the range (allows for the minimal range allowed, but tries to also allow for the highest maximum while keeping the minimal number).