### PR TITLE
[UWP] AutoFocus support

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -53,7 +53,7 @@ namespace ZXing.Mobile
         static readonly Guid RotationKey = new Guid("C380465D-2271-428C-9B83-ECEA3B4A85C1");
 
         // Prevent the screen from sleeping while the camera is running
-        readonly DisplayRequest _displayRequest = new DisplayRequest();
+        readonly DisplayRequest displayRequest = new DisplayRequest();
 
         // For listening to media property changes
         readonly SystemMediaTransportControls _systemMediaControls = SystemMediaTransportControls.GetForCurrentView();
@@ -89,6 +89,8 @@ namespace ZXing.Mobile
         {
             if (stopping)
                 return;
+
+            displayRequest.RequestActive();
 
             isAnalyzing = true;
             ScanCallback = scanCallback;
@@ -469,6 +471,8 @@ namespace ZXing.Mobile
         {
             stopping = true;
             isAnalyzing = false;
+
+            displayRequest.RequestRelease();
 
             try
             {

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -195,7 +195,7 @@ namespace ZXing.Mobile
             // Set the selected resolution
             await mediaCapture.VideoDeviceController.SetMediaStreamPropertiesAsync(MediaStreamType.VideoPreview, chosenProp);
 
-            SetPreviewRotationa();
+            SetPreviewRotation();
 
             await SetupAutoFocus();
 


### PR DESCRIPTION
For now preview picture is blurred because AutoFocus by default works only on screen tap event.

- [x] Add continuous autofocus support by default
- [x] Implement focus areas logic

Other:
- [x] Add error handlers for exceptions when camera is null
- [x] Prevent screen from sleeping
- [x] Fix preview buffer and correctly handle phone rotation
- [x] Handle mirroring on front camera
- [x] Handle external camera