### PR TITLE
Async implementation of ScanContinuously()

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.Android/MobileBarcodeScanner.cs
@@ -47,35 +47,68 @@ namespace ZXing.Mobile
 				return Android.App.Application.Context;
 		}
 
-		public override void ScanContinuously (MobileBarcodeScanningOptions options, Action<Result> scanHandler)
-		{
-			ScanContinuously (null, options, scanHandler);
-		}
+        public override void ScanContinuously(MobileBarcodeScanningOptions options, Action<Result> scanHandler)
+        {
+            ScanContinuously(null, options, scanHandler);
+        }
 
-		public void ScanContinuously (Context context, MobileBarcodeScanningOptions options, Action<Result> scanHandler)
-		{
-			var ctx = GetContext (context);
-			var scanIntent = new Intent(ctx, typeof(ZxingActivity));
+        public override async Task ScanContinuouslyAsync(MobileBarcodeScanningOptions options, Action<Result> scanHandler)
+        {
+            await ScanContinuouslyAsync(null, options, scanHandler);
+        }
 
-			scanIntent.AddFlags(ActivityFlags.NewTask);
+        public void ScanContinuously(Context context, MobileBarcodeScanningOptions options, Action<Result> scanHandler)
+        {
+            var ctx = GetContext(context);
+            var scanIntent = new Intent(ctx, typeof(ZxingActivity));
 
-			ZxingActivity.UseCustomOverlayView = this.UseCustomOverlay;
-			ZxingActivity.CustomOverlayView = this.CustomOverlay;
-			ZxingActivity.ScanningOptions = options;
-			ZxingActivity.ScanContinuously = true;
-			ZxingActivity.TopText = TopText;
-			ZxingActivity.BottomText = BottomText;
+            scanIntent.AddFlags(ActivityFlags.NewTask);
 
-			ZxingActivity.ScanCompletedHandler = (Result result) => 
-			{
-				if (scanHandler != null)
-					scanHandler (result);
-			};
+            ZxingActivity.UseCustomOverlayView = this.UseCustomOverlay;
+            ZxingActivity.CustomOverlayView = this.CustomOverlay;
+            ZxingActivity.ScanningOptions = options;
+            ZxingActivity.ScanContinuously = true;
+            ZxingActivity.TopText = TopText;
+            ZxingActivity.BottomText = BottomText;
 
-			ctx.StartActivity(scanIntent);
-		}
+            ZxingActivity.ScanCompletedHandler = (Result result) =>
+            {
+                if (scanHandler != null)
+                    scanHandler(result);
+            };
 
-		public override Task<Result> Scan (MobileBarcodeScanningOptions options)
+            ctx.StartActivity(scanIntent);
+        }
+
+        public async Task ScanContinuouslyAsync(Context context, MobileBarcodeScanningOptions options, Action<Result> scanHandler)
+        {
+            var ctx = GetContext(context);
+            var scanIntent = new Intent(ctx, typeof(ZxingActivity));
+
+            scanIntent.AddFlags(ActivityFlags.NewTask);
+
+            ZxingActivity.UseCustomOverlayView = this.UseCustomOverlay;
+            ZxingActivity.CustomOverlayView = this.CustomOverlay;
+            ZxingActivity.ScanningOptions = options;
+            ZxingActivity.ScanContinuously = true;
+            ZxingActivity.TopText = TopText;
+            ZxingActivity.BottomText = BottomText;
+
+            ZxingActivity.ScanCompletedHandler = (Result result) =>
+            {
+                if (scanHandler != null)
+                    scanHandler(result);
+            };
+
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+            ZxingActivity.CanceledHandler = () => tcs.SetResult(null);
+
+            ctx.StartActivity(scanIntent);
+
+            await tcs.Task;
+        }
+
+        public override Task<Result> Scan (MobileBarcodeScanningOptions options)
 		{
 			return Scan (null, options);
 		}

--- a/Source/ZXing.Net.Mobile.Core/IMobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.Core/IMobileBarcodeScanner.cs
@@ -64,14 +64,20 @@ namespace ZXing.Mobile
 			return Scan(MobileBarcodeScanningOptions.Default);
 		}
 
-        public void ScanContinuously (Action<Result> scanHandler)
+        public void ScanContinuously(Action<Result> scanHandler)
         {
-            ScanContinuously (MobileBarcodeScanningOptions.Default, scanHandler);
+            ScanContinuously(MobileBarcodeScanningOptions.Default, scanHandler);
+        }
+        public async Task ScanContinuouslyAsync(Action<Result> scanHandler)
+        {
+            await ScanContinuouslyAsync(MobileBarcodeScanningOptions.Default, scanHandler);
         }
 
-        public abstract void ScanContinuously (MobileBarcodeScanningOptions options, Action<Result> scanHandler);
+        public abstract void ScanContinuously(MobileBarcodeScanningOptions options, Action<Result> scanHandler);
 
-		public abstract void Cancel();
+        public abstract Task ScanContinuouslyAsync(MobileBarcodeScanningOptions options, Action<Result> scanHandler);
+
+        public abstract void Cancel();
 
 		public abstract void Torch(bool on);
 

--- a/Source/ZXing.Net.Mobile.Portable/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.Portable/MobileBarcodeScanner.cs
@@ -16,6 +16,10 @@ namespace ZXing.Mobile
         {
             throw ex;
         }
+        public override Task ScanContinuouslyAsync(MobileBarcodeScanningOptions options, Action<Result> scanHandler)
+        {
+            throw ex;
+        }
 
         public override void Cancel()
         {

--- a/Source/ZXing.Net.Mobile.WindowsPhone/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.WindowsPhone/MobileBarcodeScanner.cs
@@ -50,6 +50,37 @@ namespace ZXing.Mobile
             });
         }
 
+        public override async Task ScanContinuouslyAsync(MobileBarcodeScanningOptions options, Action<Result> scanHandler)
+        {
+            //Navigate: /ZxingSharp.WindowsPhone;component/Scan.xaml
+
+            ScanPage.ScanningOptions = options;
+            ScanPage.ResultFoundAction = (r) =>
+            {
+                scanHandler(r);
+            };
+
+            ScanPage.UseCustomOverlay = this.UseCustomOverlay;
+            ScanPage.CustomOverlay = this.CustomOverlay;
+            ScanPage.TopText = TopText;
+            ScanPage.BottomText = BottomText;
+            ScanPage.ContinuousScanning = true;
+
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+            ScanPage.OnClosed += delegate
+            {
+                tcs.SetResult(null);
+            };
+
+            Dispatcher.BeginInvoke(() =>
+            {
+                ((Microsoft.Phone.Controls.PhoneApplicationFrame)Application.Current.RootVisual).Navigate(
+                    new Uri("/ZXingNetMobile;component/ScanPage.xaml", UriKind.Relative));
+            });
+
+            await tcs.Task;
+        }
+
         public override Task<Result> Scan(MobileBarcodeScanningOptions options)
         {
             return Task.Factory.StartNew(new Func<Result>(() =>

--- a/Source/ZXing.Net.Mobile.WindowsPhone/ScanPage.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsPhone/ScanPage.xaml.cs
@@ -35,6 +35,7 @@ namespace ZXing.Mobile
         public static event Action OnRequestToggleTorch;
         public static event Action OnRequestAutoFocus;
         public static event Action OnRequestCancel;
+        public static event Action OnClosed;
         public static event Func<bool> OnRequestIsTorchOn;
         public static Action OnRequestPauseAnalysis;
         public static Action OnRequestResumeAnalysis;
@@ -91,7 +92,14 @@ namespace ZXing.Mobile
 		{
 			InitializeComponent();
 		    isNewInstance = true;
-		}
+
+            this.BackKeyPress += delegate
+            {
+                var evt = OnClosed;
+                if (evt != null)
+                    evt();
+            };
+        }
 
         void RequestAutoFocusHandler() 
         {

--- a/Source/ZXing.Net.Mobile.WindowsRT/NotSupported.cs
+++ b/Source/ZXing.Net.Mobile.WindowsRT/NotSupported.cs
@@ -34,6 +34,11 @@ namespace ZXing.Mobile
             throw ex;
         }
 
+        public override Task ScanContinuouslyAsync(MobileBarcodeScanningOptions options, Action<Result> scanHandler)
+        {
+            throw ex;
+        }
+
         public override void Cancel()
         {
             throw ex;

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/MobileBarcodeScanner.cs
@@ -25,7 +25,7 @@ namespace ZXing.Mobile
         public override void ScanContinuously(MobileBarcodeScanningOptions options, Action<Result> scanHandler)
         {
             //Navigate: /ZxingSharp.WindowsPhone;component/Scan.xaml
-            var rootFrame = RootFrame ?? Window.Current.Content as Frame ?? ((FrameworkElement) Window.Current.Content).GetFirstChildOfType<Frame>();
+            var rootFrame = RootFrame ?? Window.Current.Content as Frame ?? ((FrameworkElement)Window.Current.Content).GetFirstChildOfType<Frame>();
             var dispatcher = Dispatcher ?? Window.Current.Dispatcher;
 
             ScanPage.ScanningOptions = options;
@@ -36,11 +36,40 @@ namespace ZXing.Mobile
             ScanPage.TopText = TopText;
             ScanPage.BottomText = BottomText;
             ScanPage.ContinuousScanning = true;
-            
+
             dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 rootFrame.Navigate(typeof(ScanPage));
             });
+        }
+
+        public override async Task ScanContinuouslyAsync(MobileBarcodeScanningOptions options, Action<Result> scanHandler)
+        {
+            //Navigate: /ZxingSharp.WindowsPhone;component/Scan.xaml
+            var rootFrame = RootFrame ?? Window.Current.Content as Frame ?? ((FrameworkElement)Window.Current.Content).GetFirstChildOfType<Frame>();
+            var dispatcher = Dispatcher ?? Window.Current.Dispatcher;
+
+            ScanPage.ScanningOptions = options;
+            ScanPage.ResultFoundAction = scanHandler;
+
+            ScanPage.UseCustomOverlay = this.UseCustomOverlay;
+            ScanPage.CustomOverlay = this.CustomOverlay;
+            ScanPage.TopText = TopText;
+            ScanPage.BottomText = BottomText;
+            ScanPage.ContinuousScanning = true;
+
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+            ScanPage.OnClosed += delegate
+            {
+                tcs.SetResult(null);
+            };
+
+            dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                rootFrame.Navigate(typeof(ScanPage));
+            });
+
+            await tcs.Task;
         }
 
         public override Task<Result> Scan(MobileBarcodeScanningOptions options)

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ScanPage.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ScanPage.xaml.cs
@@ -30,6 +30,13 @@ namespace ZXing.Mobile
         {
             isNewInstance = true;
             this.InitializeComponent();
+
+            this.Unloaded += delegate
+            {
+                var evt = OnClosed;
+                if (evt != null)
+                    evt();
+            };
         }
 
         public static MobileBarcodeScanningOptions ScanningOptions { get; set; }
@@ -48,6 +55,7 @@ namespace ZXing.Mobile
         public static event Action OnRequestToggleTorch;
         public static event Action OnRequestAutoFocus;
         public static event Action OnRequestCancel;
+        public static event Action OnClosed;
         public static event Func<bool> OnRequestIsTorchOn;
         public static event Action OnRequestPauseAnalysis;
         public static event Action OnRequestResumeAnalysis;

--- a/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerViewController.cs
+++ b/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerViewController.cs
@@ -26,8 +26,9 @@ namespace ZXing.Mobile
 		AVCaptureScannerView scannerView;
 
 		public event Action<ZXing.Result> OnScannedResult;
+        public event Action OnClosed;
 
-		public MobileBarcodeScanningOptions ScanningOptions { get;set; }
+        public MobileBarcodeScanningOptions ScanningOptions { get;set; }
 		public MobileBarcodeScanner Scanner { get;set; }
         public bool ContinuousScanning { get;set; }
 
@@ -155,13 +156,17 @@ namespace ZXing.Mobile
 		{
 			UIApplication.SharedApplication.SetStatusBarStyle(originalStatusBarStyle, false);
 
-			//if (scannerView != null)
-			//	scannerView.StopScanning();
+            var evt = this.OnClosed;
+            if (evt != null)
+                evt();
 
-			//scannerView.RemoveFromSuperview();
-			//scannerView.Dispose();			
-			//scannerView = null;
-		}
+            //if (scannerView != null)
+            //	scannerView.StopScanning();
+
+            //scannerView.RemoveFromSuperview();
+            //scannerView.Dispose();			
+            //scannerView = null;
+        }
 
 		public override void DidRotate (UIInterfaceOrientation fromInterfaceOrientation)
 		{

--- a/Source/ZXing.Net.Mobile.iOS/IScannerViewController.cs
+++ b/Source/ZXing.Net.Mobile.iOS/IScannerViewController.cs
@@ -22,8 +22,9 @@ namespace ZXing.Mobile
         void ResumeAnalysis ();
 
 		event Action<ZXing.Result> OnScannedResult;
+        event Action OnClosed;
 
-		MobileBarcodeScanningOptions ScanningOptions { get;set; }
+        MobileBarcodeScanningOptions ScanningOptions { get;set; }
 		MobileBarcodeScanner Scanner { get;set; }
 
 		UIViewController AsViewController();

--- a/Source/ZXing.Net.Mobile.iOS/ZXingScannerViewController.cs
+++ b/Source/ZXing.Net.Mobile.iOS/ZXingScannerViewController.cs
@@ -28,8 +28,9 @@ namespace ZXing.Mobile
 		ZXingScannerView scannerView;
 
 		public event Action<ZXing.Result> OnScannedResult;
+        public event Action OnClosed;
 
-		public MobileBarcodeScanningOptions ScanningOptions { get;set; }
+        public MobileBarcodeScanningOptions ScanningOptions { get;set; }
 		public MobileBarcodeScanner Scanner { get;set; }
         public bool ContinuousScanning { get;set; }
 
@@ -166,7 +167,11 @@ namespace ZXing.Mobile
 		public override void ViewWillDisappear(bool animated)
 		{
 			UIApplication.SharedApplication.SetStatusBarStyle(originalStatusBarStyle, false);
-		}
+
+            var evt = this.OnClosed;
+            if (evt != null)
+                evt();
+        }
 
 		public override void DidRotate (UIInterfaceOrientation fromInterfaceOrientation)
 		{


### PR DESCRIPTION
This async implementation of ScanContinuously() awaits the end of the user input (when it presses back / cancels the view).

The « Cancel » button should probably be renamed with « Done » by default on iOS (I do this manually at the moment).

Feel free to discuss or improve all this (as it is a very basic implementation).

I based this commit on my implementation (which was made 6 month ago) but I did not have the time to test it on each platform again with the code that was added during these 6 monthes (I am in a big rush).

Please also note that I have never been able to test this on UWP. The implementation is still theoretical but is very close to the W8 one.
