### PR TITLE
Fix crashes on UWP desktop with webcam

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -551,8 +551,7 @@ namespace ZXing.Mobile
         /// </summary>
         private async Task SetPreviewRotationAsync()
         {
-            // Only need to update the orientation if the camera is mounted on the device.
-            if (mediaCapture == null || externalCamera)
+            if (mediaCapture == null)
                 return;
 
             // Calculate which way and how far to rotate the preview.

--- a/Source/ZXing.Net/common/DefaultGridSampler.cs
+++ b/Source/ZXing.Net/common/DefaultGridSampler.cs
@@ -56,24 +56,23 @@ namespace ZXing.Common
             // sufficient to check the endpoints
             if (!checkAndNudgePoints(image, points))
                return null;
-            try
+
+            for (int x = 0; x < max; x += 2)
             {
-               for (int x = 0; x < max; x += 2)
-               {
-                  //UPGRADE_WARNING: Data types in Visual C# might be different.  Verify the accuracy of narrowing conversions. "ms-help://MS.VSCC.v80/dv_commoner/local/redirect.htm?index='!DefaultContextWindowIndex'&keyword='jlca1042'"
-                  bits[x >> 1, y] = image[(int)points[x], (int)points[x + 1]];
-               }
-            }
-            catch (System.IndexOutOfRangeException)
-            {
+               //UPGRADE_WARNING: Data types in Visual C# might be different.  Verify the accuracy of narrowing conversions. "ms-help://MS.VSCC.v80/dv_commoner/local/redirect.htm?index='!DefaultContextWindowIndex'&keyword='jlca1042'"
+               int imagex = (int)points[x];
+               int imagey = (int)points[x + 1];
+
                // This feels wrong, but, sometimes if the finder patterns are misidentified, the resulting
                // transform gets "twisted" such that it maps a straight line of points to a set of points
                // whose endpoints are in bounds, but others are not. There is probably some mathematical
                // way to detect this about the transformation that I don't know yet.
-               // This results in an ugly runtime exception despite our clever checks above -- can't have
-               // that. We could check each point's coordinates but that feels duplicative. We settle for
-               // catching and wrapping ArrayIndexOutOfBoundsException.
-               return null;
+               if (imagex < 0 || imagex > image.Width || imagey < 0 || imagey > image.Height)
+               {
+                  return null;
+               }
+
+               bits[x >> 1, y] = image[(int)points[x], (int)points[x + 1]];
             }
          }
          return bits;


### PR DESCRIPTION
If a webcam on a desktop is used, I kept running into two errors:

- The videoFrame was never set in the control because there was an explicit check for mounted camera that seemed unnecessary
- An IndexOutOfRange exception was continually thrown. I added a manual bounds check that should prevent first chance exceptions from catching during debugging as well as a performance gain as catching exceptions are much slower than manually checking bounds.