### PR TITLE
Fix HintPath for some NuGet references in sample projects

### DIFF
--- a/Samples/Android/Sample.Android/Sample.Android.csproj
+++ b/Samples/Android/Sample.Android/Sample.Android.csproj
@@ -45,7 +45,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\packages\Xamarin.Android.Support.v4.23.0.1.3\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.v4.23.0.1.3\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/Forms/iOS/FormsSample.iOS.csproj
+++ b/Samples/Forms/iOS/FormsSample.iOS.csproj
@@ -96,7 +96,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Calabash">
-      <HintPath>..\packages\Xamarin.TestCloud.Agent.0.19.2\lib\Xamarin.iOS10\Calabash.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.TestCloud.Agent.0.19.2\lib\Xamarin.iOS10\Calabash.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/iOS/Sample.iOS/Sample.iOS.csproj
+++ b/Samples/iOS/Sample.iOS/Sample.iOS.csproj
@@ -95,7 +95,7 @@
     <Reference Include="Xamarin.iOS" />
     <Reference Include="MonoTouch.Dialog-1" />
     <Reference Include="Calabash">
-      <HintPath>..\packages\Xamarin.TestCloud.Agent.0.19.2\lib\Xamarin.iOS10\Calabash.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.TestCloud.Agent.0.19.2\lib\Xamarin.iOS10\Calabash.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This commit corrects some hintpaths in the sample projects
