### PR TITLE
Remove external cam check in SetPreviewRotationAsync

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -550,9 +550,8 @@ namespace ZXing.Mobile
         /// Gets the current orientation of the UI in relation to the device and applies a corrective rotation to the preview
         /// </summary>
         private async Task SetPreviewRotationAsync()
-        {
-            // Only need to update the orientation if the camera is mounted on the device.
-            if (mediaCapture == null || externalCamera)
+        {            
+            if (mediaCapture == null)
                 return;
 
             // Calculate which way and how far to rotate the preview.


### PR DESCRIPTION
When using external camera, the videoFrame was not initialized which caused ArgumentException.

This fixes the issue #369