### PR TITLE
Change visibility of member variables in renderers, to ease inheriting.

### DIFF
--- a/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
+++ b/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
@@ -29,9 +29,9 @@ namespace ZXing.Net.Mobile.Forms.Android
             var temp = DateTime.Now;
         }
 
-        ZXingScannerView formsView;
+        protected ZXingScannerView formsView;
 
-        internal ZXingSurfaceView zxingSurface;
+        protected ZXingSurfaceView zxingSurface;
         internal Task<bool> requestPermissionsTask;
 
         protected override async void OnElementChanged(ElementChangedEventArgs<ZXingScannerView> e)

--- a/Source/ZXing.Net.Mobile.Forms.WindowsPhone/ZXingScannerViewRenderer.cs
+++ b/Source/ZXing.Net.Mobile.Forms.WindowsPhone/ZXingScannerViewRenderer.cs
@@ -17,9 +17,9 @@ namespace ZXing.Net.Mobile.Forms.WindowsPhone
             // Force the assembly to load
         }
 
-        ZXingScannerView formsView;
+        protected ZXingScannerView formsView;
 
-        ZXing.Mobile.ZXingScannerControl zxingControl;
+        protected ZXing.Mobile.ZXingScannerControl zxingControl;
 
         protected override void OnElementChanged(ElementChangedEventArgs<ZXingScannerView> e)
         {

--- a/Source/ZXing.Net.Mobile.Forms.WindowsUniversal/ZXingScannerViewRenderer.cs
+++ b/Source/ZXing.Net.Mobile.Forms.WindowsUniversal/ZXingScannerViewRenderer.cs
@@ -17,9 +17,9 @@ namespace ZXing.Net.Mobile.Forms.WindowsUniversal
             // Cause the assembly to load
         }
 
-        ZXingScannerView formsView;
+        protected ZXingScannerView formsView;
 
-        ZXing.Mobile.ZXingScannerControl zxingControl;
+        protected ZXing.Mobile.ZXingScannerControl zxingControl;
 
         protected override void OnElementChanged(ElementChangedEventArgs<ZXingScannerView> e)
         {

--- a/Source/ZXing.Net.Mobile.Forms.iOS/ZXingScannerViewRenderer.cs
+++ b/Source/ZXing.Net.Mobile.Forms.iOS/ZXingScannerViewRenderer.cs
@@ -20,8 +20,8 @@ namespace ZXing.Net.Mobile.Forms.iOS
             var temp = DateTime.Now;
         }
 
-        ZXingScannerView formsView;
-        ZXing.Mobile.ZXingScannerView zxingView;
+        protected ZXingScannerView formsView;
+        protected ZXing.Mobile.ZXingScannerView zxingView;
 
         protected override void OnElementChanged(ElementChangedEventArgs<ZXingScannerView> e)
         {


### PR DESCRIPTION
As briefly described in #401 it would help a lot of member variables in renderers were protected instead of private. This would ease making small changes to the default renderers in zxing.