### PR TITLE
fixed autofocus on droid

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -181,10 +181,13 @@ namespace ZXing.Mobile
 
             // First try continuous video, then auto focus, then fixed
             var supportedFocusModes = parameters.SupportedFocusModes;
-            if (supportedFocusModes.Contains (Camera.Parameters.FocusModeAuto))
-                parameters.FocusMode = Camera.Parameters.FocusModeAuto;
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.IceCreamSandwich && 
+                supportedFocusModes.Contains (Camera.Parameters.FocusModeContinuousPicture))
+                parameters.FocusMode = Camera.Parameters.FocusModeContinuousPicture;
             else if (supportedFocusModes.Contains (Camera.Parameters.FocusModeContinuousVideo))
                 parameters.FocusMode = Camera.Parameters.FocusModeContinuousVideo;
+            else if (supportedFocusModes.Contains(Camera.Parameters.FocusModeAuto))
+                parameters.FocusMode = Camera.Parameters.FocusModeAuto;
             else if (supportedFocusModes.Contains (Camera.Parameters.FocusModeFixed))
                 parameters.FocusMode = Camera.Parameters.FocusModeFixed;
 


### PR DESCRIPTION
Added modern autofocus mode and changed types priority (possible fix for #395).
Picture mode works much better than any other in our case.