### PR TITLE
Use TextureView instead of SurfaceView on Android.

### DIFF
--- a/Samples/Forms/Core/CustomScanPage.cs
+++ b/Samples/Forms/Core/CustomScanPage.cs
@@ -21,6 +21,15 @@ namespace FormsSample
                 VerticalOptions = LayoutOptions.FillAndExpand,
                 AutomationId = "zxingScannerView",
             };
+
+			var formats = zxing.Options.PossibleFormats;
+			formats.Clear();
+			formats.Add(ZXing.BarcodeFormat.CODE_128);
+			formats.Add(ZXing.BarcodeFormat.CODE_39);
+			formats.Add(ZXing.BarcodeFormat.QR_CODE);
+
+			zxing.IsTorchOn = true;
+
             zxing.OnScanResult += (result) => 
                 Device.BeginInvokeOnMainThread (async () => {
 
@@ -30,8 +39,7 @@ namespace FormsSample
                     // Show an alert
                     await DisplayAlert ("Scanned Barcode", result.Text, "OK");
 
-                    // Navigate away
-                    await Navigation.PopAsync ();
+					zxing.IsAnalyzing = true;
                 });
 
             overlay = new ZXingDefaultOverlay
@@ -46,6 +54,10 @@ namespace FormsSample
             };
             var grid = new Grid
             {
+				RowDefinitions = {
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }
+				},
                 VerticalOptions = LayoutOptions.FillAndExpand,
                 HorizontalOptions = LayoutOptions.FillAndExpand,
             };

--- a/Samples/Forms/Droid/FormsSample.Droid.csproj
+++ b/Samples/Forms/Droid/FormsSample.Droid.csproj
@@ -15,7 +15,7 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>FormsSample.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -29,6 +29,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -39,6 +40,7 @@
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <ConsolePause>false</ConsolePause>
     <AndroidSupportedAbis>armeabi;armeabi-v7a;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Source/ZXing.Net.Mobile.Android/CameraExtensions.cs
+++ b/Source/ZXing.Net.Mobile.Android/CameraExtensions.cs
@@ -1,0 +1,130 @@
+// <copyright company="APX Labs, Inc.">
+//     Copyright (c) APX Labs, Inc. All rights reserved.
+// </copyright>
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// Many thanks to Jonathan Pryor from Xamarin for his assistance
+
+using System;
+using Android.Hardware;
+using Android.Runtime;
+
+namespace ApxLabs.FastAndroidCamera
+{
+	public static class CameraExtensions
+	{
+		static IntPtr id_addCallbackBuffer_arrayB;
+		public static void AddCallbackBuffer(this Camera self, FastJavaByteArray callbackBuffer)
+		{
+			if (id_addCallbackBuffer_arrayB == IntPtr.Zero)
+				id_addCallbackBuffer_arrayB = JNIEnv.GetMethodID(self.Class.Handle, "addCallbackBuffer", "([B)V");
+			JNIEnv.CallVoidMethod(self.Handle, id_addCallbackBuffer_arrayB, new JValue(callbackBuffer.Handle));
+		}
+
+		static IntPtr id_setPreviewCallback_Landroid_hardware_Camera_PreviewCallback_;
+		public static void SetNonMarshalingPreviewCallback(this Camera self, INonMarshalingPreviewCallback cb)
+		{
+			if (id_setPreviewCallback_Landroid_hardware_Camera_PreviewCallback_ == IntPtr.Zero)
+				id_setPreviewCallback_Landroid_hardware_Camera_PreviewCallback_ = JNIEnv.GetMethodID(self.Class.Handle, "setPreviewCallbackWithBuffer", "(Landroid/hardware/Camera$PreviewCallback;)V");
+			JNIEnv.CallVoidMethod(self.Handle, id_setPreviewCallback_Landroid_hardware_Camera_PreviewCallback_, new JValue(cb));
+		}
+
+		static IntPtr id_setOneShotPreviewCallback_Landroid_hardware_Camera_PreviewCallback_;
+		public static void SetNonMarshalingOneShotPreviewCallback(this Camera self, INonMarshalingPreviewCallback cb)
+		{
+			if (id_setOneShotPreviewCallback_Landroid_hardware_Camera_PreviewCallback_ == IntPtr.Zero)
+				id_setOneShotPreviewCallback_Landroid_hardware_Camera_PreviewCallback_ = JNIEnv.GetMethodID(self.Class.Handle, "setOneShotPreviewCallback", "(Landroid/hardware/Camera$PreviewCallback;)V");
+			JNIEnv.CallVoidMethod(self.Handle, id_setOneShotPreviewCallback_Landroid_hardware_Camera_PreviewCallback_, new JValue(cb));
+		}
+	}
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='android.hardware']/interface[@name='Camera.PreviewCallback']"
+	[Register("android/hardware/Camera$PreviewCallback", "", "ApxLabs.FastAndroidCamera.INonMarshalingPreviewCallbackInvoker")]
+	public interface INonMarshalingPreviewCallback : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='android.hardware']/interface[@name='Camera.PreviewCallback']/method[@name='onPreviewFrame' and count(parameter)=2 and parameter[1][@type='byte[]'] and parameter[2][@type='android.hardware.Camera']]"
+//		[Register("onPreviewFrame", "([BLandroid/hardware/Camera;)V", "GetOnPreviewFrame_arrayBLandroid_hardware_Camera_Handler:ApxLabs.FastAndroidCamera.INonMarshalingPreviewCallbackInvoker, FastAndroidCamera, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		[Register("onPreviewFrame", "([BLandroid/hardware/Camera;)V", "GetOnPreviewFrame_arrayBLandroid_hardware_Camera_Handler:ApxLabs.FastAndroidCamera.INonMarshalingPreviewCallbackInvoker, ZXingNetMobile, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void OnPreviewFrame(IntPtr data, Camera camera);
+	}
+
+	[Register("android/hardware/Camera$PreviewCallback", DoNotGenerateAcw=true)]
+	internal class INonMarshalingPreviewCallbackInvoker : Java.Lang.Object, INonMarshalingPreviewCallback {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass("android/hardware/Camera$PreviewCallback");
+		IntPtr class_ref;
+
+		public static INonMarshalingPreviewCallback GetObject(IntPtr handle, JniHandleOwnership transfer)
+		{
+			return GetObject<INonMarshalingPreviewCallback>(handle, transfer);
+		}
+
+		static IntPtr Validate(IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf(handle, java_class_ref))
+				throw new InvalidCastException(string.Format("Unable to convert instance of type '{0}' to type '{1}'.",
+				                                               JNIEnv.GetClassNameFromInstance(handle), "android.hardware.Camera.PreviewCallback"));
+			return handle;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef(class_ref);
+			class_ref = IntPtr.Zero;
+			base.Dispose(disposing);
+		}
+
+		public INonMarshalingPreviewCallbackInvoker(IntPtr handle, JniHandleOwnership transfer)
+			: base(Validate(handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass(Handle);
+			class_ref = JNIEnv.NewGlobalRef(local_ref);
+			JNIEnv.DeleteLocalRef(local_ref);
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override Type ThresholdType {
+			get { return typeof(INonMarshalingPreviewCallbackInvoker); }
+		}
+
+		static Delegate cb_onPreviewFrame_arrayBLandroid_hardware_Camera_;
+		#pragma warning disable 0169
+		static Delegate GetOnPreviewFrame_arrayBLandroid_hardware_Camera_Handler()
+		{
+			if (cb_onPreviewFrame_arrayBLandroid_hardware_Camera_ == null)
+				cb_onPreviewFrame_arrayBLandroid_hardware_Camera_ = JNINativeWrapper.CreateDelegate((Action<IntPtr, IntPtr, IntPtr, IntPtr>) n_OnPreviewFrame_arrayBLandroid_hardware_Camera_);
+			return cb_onPreviewFrame_arrayBLandroid_hardware_Camera_;
+		}
+
+		static void n_OnPreviewFrame_arrayBLandroid_hardware_Camera_(IntPtr jnienv, IntPtr native__this, IntPtr native_data, IntPtr native_camera)
+		{
+			INonMarshalingPreviewCallback __this = GetObject<INonMarshalingPreviewCallback>(native__this, JniHandleOwnership.DoNotTransfer);
+			Camera camera = GetObject<Camera>(native_camera, JniHandleOwnership.DoNotTransfer);
+			__this.OnPreviewFrame(native_data, camera);
+		}
+		#pragma warning restore 0169
+
+		IntPtr id_onPreviewFrame_arrayBLandroid_hardware_Camera_;
+		public void OnPreviewFrame(IntPtr data, Camera camera)
+		{
+			if (id_onPreviewFrame_arrayBLandroid_hardware_Camera_ == IntPtr.Zero)
+				id_onPreviewFrame_arrayBLandroid_hardware_Camera_ = JNIEnv.GetMethodID(class_ref, "onPreviewFrame", "([BLandroid/hardware/Camera;)V");
+			JNIEnv.CallVoidMethod(Handle, id_onPreviewFrame_arrayBLandroid_hardware_Camera_, new JValue(data), new JValue(camera));
+		}
+	}
+}

--- a/Source/ZXing.Net.Mobile.Android/FastJavaByteArray.cs
+++ b/Source/ZXing.Net.Mobile.Android/FastJavaByteArray.cs
@@ -1,0 +1,293 @@
+// <copyright company="APX Labs, Inc.">
+//     Copyright (c) APX Labs, Inc. All rights reserved.
+// </copyright>
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+using System.Runtime.InteropServices;
+using Android.Runtime;
+using System.Collections.Generic;
+using System;
+using System.Diagnostics;
+using System.Collections;
+using Java.Interop;
+
+namespace ApxLabs.FastAndroidCamera
+{
+	/// <summary>
+	/// A wrapper around a Java array that reads elements directly from the pointer instead of through
+	/// expensive JNI calls.
+	/// </summary>
+	public sealed class FastJavaByteArray : Java.Lang.Object, IList<byte>
+	{
+		#region Constructors
+
+		/// <summary>
+		/// Creates a new FastJavaByteArray with the given number of bytes reserved.
+		/// </summary>
+		/// <param name="length">Number of bytes to reserve</param>
+		public FastJavaByteArray(int length)
+		{
+			if (length <= 0)
+				throw new ArgumentOutOfRangeException();
+
+			var arrayHandle = JniEnvironment.Arrays.NewByteArray(length).Handle;
+			if (arrayHandle == IntPtr.Zero)
+				throw new OutOfMemoryException();
+
+			// Retain a global reference to the byte array. NewByteArray() returns a local ref, and TransferLocalRef
+			// creates a new global ref to the array and deletes the local ref.
+			SetHandle(arrayHandle, JniHandleOwnership.TransferLocalRef);
+			Count = length;
+
+			bool isCopy = false;
+			unsafe
+			{
+				// Get the pointer to the byte array using the global Handle
+				Raw = (byte*)JniEnvironment.Arrays.GetByteArrayElements(PeerReference, &isCopy);
+			}
+
+		}
+
+		/// <summary>
+		/// Creates a FastJavaByteArray wrapper around an existing Java/JNI byte array
+		/// </summary>
+		/// <param name="handle">Native Java array handle</param>
+		/// <param name="readOnly">Whether to consider this byte array read-only</param>
+		public FastJavaByteArray(IntPtr handle, bool readOnly=true) : base(handle, JniHandleOwnership.DoNotTransfer)
+		{
+			// DoNotTransfer is used to leave the incoming handle alone; that reference was created in Java, so it's
+			// Java's responsibility to delete it. DoNotTransfer creates a global reference to use here in the CLR
+			if (handle == IntPtr.Zero)
+				throw new ArgumentNullException("handle");
+
+			IsReadOnly = readOnly;
+
+			Count = JNIEnv.GetArrayLength(Handle);
+			bool isCopy = false;
+			unsafe
+			{
+				// Get the pointer to the byte array using the global Handle
+				Raw = (byte*)JniEnvironment.Arrays.GetByteArrayElements(PeerReference, &isCopy);
+			}
+		}
+
+		#endregion
+
+		protected override void Dispose(bool disposing)
+		{
+			unsafe
+			{
+				if (Raw != null && Handle != IntPtr.Zero) // tell Java that we're done with this array
+					JniEnvironment.Arrays.ReleaseByteArrayElements(PeerReference, (sbyte*)Raw, IsReadOnly ? JniReleaseArrayElementsMode.Default : JniReleaseArrayElementsMode.Commit);
+
+				Raw = null;
+			}
+			base.Dispose(disposing);
+		}
+
+		#region IList<byte> Properties
+
+		/// <summary>
+		/// Count of bytes
+		/// </summary>
+		public int Count { get; private set; }
+
+		/// <summary>
+		/// Gets a value indicating whether this byte array is read only.
+		/// </summary>
+		/// <value><c>true</c> if read only; otherwise, <c>false</c>.</value>
+		public bool IsReadOnly
+		{
+			get;
+			private set;
+		}
+
+		/// <summary>
+		/// Indexer
+		/// </summary>
+		/// <param name="index">Index of byte</param>
+		/// <returns>Byte at the given index</returns>
+		public byte this[int index]
+		{
+			get
+			{
+				if (index < 0 || index >= Count)
+				{
+					throw new ArgumentOutOfRangeException();
+				}
+				byte retval;
+				unsafe
+				{
+					retval = Raw[index];
+				}
+				return retval;
+			}
+			set
+			{
+				if (IsReadOnly)
+				{
+					throw new NotSupportedException("This FastJavaByteArray is read-only");
+				}
+
+				if (index < 0 || index >= Count)
+				{
+					throw new ArgumentOutOfRangeException();
+				}
+				unsafe
+				{
+					Raw[index] = value;
+				}
+			}
+		}
+
+		#endregion
+
+		#region IList<byte> Methods
+
+		/// <summary>
+		/// Adds a single byte to the list. Not supported
+		/// </summary>
+		/// <param name="item">byte to add</param>
+		public void Add(byte item)
+		{
+			throw new NotSupportedException("FastJavaByteArray is fixed length");
+		}
+
+		/// <summary>
+		/// Not supported
+		/// </summary>
+		public void Clear()
+		{
+			throw new NotSupportedException("FastJavaByteArray is fixed length");
+		}
+
+		/// <summary>
+		/// Returns true if the item is found int he array
+		/// </summary>
+		/// <param name="item">Item to find</param>
+		/// <returns>True if the item is found</returns>
+		public bool Contains(byte item)
+		{
+			return IndexOf(item) >= 0;
+		}
+
+		/// <summary>
+		/// Copies the contents of the FastJavaByteArray into a byte array
+		/// </summary>
+		/// <param name="array">The array to copy to.</param>
+		/// <param name="arrayIndex">The zero-based index into the destination array where CopyTo should start.</param>
+		public void CopyTo(byte[] array, int arrayIndex)
+		{
+			unsafe
+			{
+				Marshal.Copy(new IntPtr(Raw), array, arrayIndex, Math.Min(Count, array.Length - arrayIndex));
+			}
+		}
+
+		/// <summary>
+		/// Copies a block of the FastJavaByteArray into a byte array
+		/// </summary>
+		/// <param name="sourceIndex">The zero-based index into the source where copy should start copying from.</param>
+		/// <param name="array">The array to copy to.</param>
+		/// <param name="arrayIndex">The zero-based index into the destination array where copy should start copying to.</param>
+		/// <param name="length">The length of the block to copy.</param>
+		public void BlockCopyTo(int sourceIndex, byte[] array, int arrayIndex, int length)
+		{
+			unsafe
+			{
+				Marshal.Copy(new IntPtr(Raw+sourceIndex), array, arrayIndex, Math.Min(length, Math.Min(Count, array.Length - arrayIndex)));
+			}
+		}
+
+		/// <summary>
+		/// Retreives enumerator
+		/// </summary>
+		/// <returns>Enumerator</returns>
+		[DebuggerHidden]
+		public IEnumerator<byte> GetEnumerator()
+		{
+			return new FastJavaByteArrayEnumerator(this);
+		}
+
+		/// <summary>
+		/// Retreives enumerator
+		/// </summary>
+		/// <returns>Enumerator</returns>
+		[DebuggerHidden]
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return new FastJavaByteArrayEnumerator(this);
+		}
+
+		/// <summary>
+		/// Gets the first index of the given value
+		/// </summary>
+		/// <param name="item">Item to search for</param>
+		/// <returns>Index of found item</returns>
+		public int IndexOf(byte item)
+		{
+			for (int i = 0; i < Count; ++i)
+			{
+				byte current;
+				unsafe
+				{
+					current = Raw[i];
+				}
+				if (current == item)
+					return i;
+			}
+			return -1;
+		}
+
+		/// <summary>
+		/// Not supported
+		/// </summary>
+		/// <param name="index"></param>
+		/// <param name="item"></param>
+		public void Insert(int index, byte item)
+		{
+			throw new NotSupportedException("FastJavaByteArray is fixed length");
+		}
+
+		/// <summary>
+		/// Not supported
+		/// </summary>
+		/// <param name="item"></param>
+		/// <returns></returns>
+		public bool Remove(byte item)
+		{
+			throw new NotSupportedException("FastJavaByteArray is fixed length");
+		}
+
+		/// <summary>
+		/// Not supported
+		/// </summary>
+		/// <param name="index"></param>
+		public void RemoveAt(int index)
+		{
+			throw new NotSupportedException("FastJavaByteArray is fixed length");
+		}
+
+		#endregion
+
+		#region Public Properties
+
+		/// <summary>
+		/// Get the raw pointer to the underlying data.
+		/// </summary>
+		public unsafe byte* Raw { get; private set; }
+
+		#endregion
+	}
+}

--- a/Source/ZXing.Net.Mobile.Android/FastJavaByteArrayEnumerator.cs
+++ b/Source/ZXing.Net.Mobile.Android/FastJavaByteArrayEnumerator.cs
@@ -1,0 +1,83 @@
+// <copyright company="APX Labs, Inc.">
+//     Copyright (c) APX Labs, Inc. All rights reserved.
+// </copyright>
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace ApxLabs.FastAndroidCamera
+{
+	internal class FastJavaByteArrayEnumerator : IEnumerator<byte>
+	{
+		internal FastJavaByteArrayEnumerator(FastJavaByteArray arr)
+		{
+			if (arr == null)
+				throw new ArgumentNullException();
+
+			_arr = arr;
+			_idx = 0;
+		}
+
+		public byte Current
+		{
+			get
+			{
+				byte retval;
+				unsafe {
+					// get value from pointer
+					retval = _arr.Raw[_idx];
+				}
+				return retval; 
+			}
+		}
+
+		public void Dispose()
+		{
+		}
+
+		public bool MoveNext()
+		{
+			if (_idx > _arr.Count)
+				return false;
+
+			++_idx;
+
+			return _idx < _arr.Count;
+		}
+
+		public void Reset()
+		{
+			_idx = 0;
+		}
+
+		#region IEnumerator implementation
+
+		object System.Collections.IEnumerator.Current {
+			get {
+				byte retval;
+				unsafe {
+					// get value from pointer
+					retval = _arr.Raw[_idx];
+				}
+				return retval; 
+			}
+		}
+
+		#endregion
+
+		FastJavaByteArray _arr;
+		int _idx;
+	}
+}

--- a/Source/ZXing.Net.Mobile.Android/FastJavaByteArrayYUVLuminanceSource.cs
+++ b/Source/ZXing.Net.Mobile.Android/FastJavaByteArrayYUVLuminanceSource.cs
@@ -1,0 +1,207 @@
+﻿/*
+ * Copyright 2009 ZXing authors
+ * Modifications copyright 2016 kasper@byolimit.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using ApxLabs.FastAndroidCamera;
+
+using System;
+
+namespace ZXing.Mobile
+{
+	/// <summary>
+	/// This object extends LuminanceSource around an array of YUV data returned from the camera driver,
+	/// with the option to crop to a rectangle within the full data. This can be used to exclude
+	/// superfluous pixels around the perimeter and speed up decoding.
+	/// It works for any pixel format where the Y channel is planar and appears first, including
+	/// YCbCr_420_SP and YCbCr_422_SP.
+	/// </summary>
+	/// <remarks>
+	/// Builds upon PlanarYUVLuminanceSource from ZXing.NET, which is a .Net port of ZXing. The original code
+	/// was authored by
+	/// @author dswitkin@google.com (Daniel Switkin)
+	/// </remarks>
+	public sealed class FastJavaByteArrayYUVLuminanceSource : BaseLuminanceSource
+	{
+		private readonly FastJavaByteArray _yuv;
+		private readonly int _dataWidth;
+		private readonly int _dataHeight;
+		private readonly int _left;
+		private readonly int _top;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PlanarYUVLuminanceSource"/> class.
+		/// </summary>
+		/// <param name="yuvData">The yuv data.</param>
+		/// <param name="dataWidth">Width of the data.</param>
+		/// <param name="dataHeight">Height of the data.</param>
+		/// <param name="left">The left.</param>
+		/// <param name="top">The top.</param>
+		/// <param name="width">The width.</param>
+		/// <param name="height">The height.</param>
+		/// <param name="reverseHoriz">if set to <c>true</c> [reverse horiz].</param>
+		public FastJavaByteArrayYUVLuminanceSource(FastJavaByteArray yuv,
+			int dataWidth,
+			int dataHeight,
+			int left,
+			int top,
+			int width,
+			int height)
+			: base(width, height)
+		{
+			if (left < 0)
+				throw new ArgumentException("Negative value", nameof(left));
+
+			if (top < 0)
+				throw new ArgumentException("Negative value", nameof(top));
+			
+			if (width < 0)
+				throw new ArgumentException("Negative value", nameof(width));
+
+			if (height < 0)
+				throw new ArgumentException("Negative value", nameof(height));
+
+			if (left + width > dataWidth || top + height > dataHeight)
+			{
+				throw new ArgumentException("Crop rectangle does not fit within image data.");
+			}
+
+			_yuv = yuv;
+			_dataWidth = dataWidth;
+			_dataHeight = dataHeight;
+			_left = left;
+			_top = top;
+		}
+
+		/// <summary>
+		/// Fetches one row of luminance data from the underlying platform's bitmap. Values range from
+		/// 0 (black) to 255 (white). Because Java does not have an unsigned byte type, callers will have
+		/// to bitwise and with 0xff for each value. It is preferable for implementations of this method
+		/// to only fetch this row rather than the whole image, since no 2D Readers may be installed and
+		/// getMatrix() may never be called.
+		/// </summary>
+		/// <param name="y">The row to fetch, 0 &lt;= y &lt; Height.</param>
+		/// <param name="row">An optional preallocated array. If null or too small, it will be ignored.
+		/// Always use the returned object, and ignore the .length of the array.</param>
+		/// <returns>
+		/// An array containing the luminance data of the requested row.
+		/// </returns>
+		override public byte[] getRow(int y, byte[] row)
+		{
+			if (y < 0 || y >= Height)
+				throw new ArgumentException("Requested row is outside the image: " + y, nameof(y));
+
+			int width = Width;
+			if (row == null || row.Length < width)
+				row = new byte[width]; // ensure we have room for the row
+
+			int offset = (y + _top) * _dataWidth + _left;
+			_yuv.BlockCopyTo(offset, row, 0, width);
+			return row;
+		}
+
+		override public byte[] Matrix
+		{
+			get
+			{
+				int width = Width;
+				int height = Height;
+
+				int area = width * height;
+				byte[] matrix = new byte[area];
+				int inputOffset = _top * _dataWidth + _left;
+
+				// If the width matches the full width of the underlying data, perform a single copy.
+				if (width == _dataWidth)
+				{
+					_yuv.BlockCopyTo (inputOffset, matrix, 0, area);
+					return matrix;
+				}
+
+				// Otherwise copy one cropped row at a time.
+				for (int y = 0; y < height; y++)
+				{
+					int outputOffset = y * width;
+					_yuv.BlockCopyTo(inputOffset, matrix, outputOffset, width);
+					inputOffset += _dataWidth;
+				}
+				return matrix;
+			}
+		}
+
+		public void CopyMatrix(ref byte[] matrix) {
+			int width = Width;
+			int height = Height;
+
+			int area = width * height;
+
+			if (area != (matrix?.Length ?? -1)) {
+				matrix = new byte[area];
+			}
+
+			int inputOffset = _top * _dataWidth + _left;
+
+			if (width == _dataWidth)
+			{
+				// If the width matches the full width of the underlying data, perform a single copy.
+				_yuv.BlockCopyTo(inputOffset, matrix, 0, area);
+			}
+			else {
+				// Otherwise copy one cropped row at a time.
+				for (int y = 0; y < height; y++)
+				{
+					int outputOffset = y * width;
+					_yuv.BlockCopyTo(inputOffset, matrix, outputOffset, width);
+					inputOffset += _dataWidth;
+				}
+			}
+		}
+
+		/// <returns> Whether this subclass supports cropping.</returns>
+		override public bool CropSupported
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Returns a new object with cropped image data. Implementations may keep a reference to the
+		/// original data rather than a copy. Only callable if CropSupported is true.
+		/// </summary>
+		/// <param name="left">The left coordinate, 0 &lt;= left &lt; Width.</param>
+		/// <param name="top">The top coordinate, 0 &lt;= top &lt;= Height.</param>
+		/// <param name="width">The width of the rectangle to crop.</param>
+		/// <param name="height">The height of the rectangle to crop.</param>
+		/// <returns>
+		/// A cropped version of this object.
+		/// </returns>
+		override public LuminanceSource crop(int left, int top, int width, int height)
+		{
+			return new FastJavaByteArrayYUVLuminanceSource(_yuv,
+				_dataWidth,
+				_dataHeight,
+				_left + left,
+				_top + top,
+				width,
+				height);
+		}
+
+		protected override LuminanceSource CreateLuminanceSource(byte[] newLuminances, int width, int height)
+		{
+			// Called when rotating. 
+			// todo: This partially defeats the purpose as we traffic in byte[] luminances
+			return new PlanarYUVLuminanceSource(newLuminances, width, height, 0, 0, width, height, false);
+		}
+	}
+}

--- a/Source/ZXing.Net.Mobile.Android/ZXing.Net.Mobile.Android.csproj
+++ b/Source/ZXing.Net.Mobile.Android/ZXing.Net.Mobile.Android.csproj
@@ -21,6 +21,7 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <DefineConstants>MONODROID;DEBUG</DefineConstants>
     <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -29,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <DefineConstants>MONODROID</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -53,6 +55,11 @@
     <Compile Include="ZXingScannerFragment.cs" />
     <Compile Include="ZXingSurfaceView.cs" />
     <Compile Include="Permissions.cs" />
+    <Compile Include="ZXingTextureView.cs" />
+    <Compile Include="CameraExtensions.cs" />
+    <Compile Include="FastJavaByteArray.cs" />
+    <Compile Include="FastJavaByteArrayEnumerator.cs" />
+    <Compile Include="FastJavaByteArrayYUVLuminanceSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Source/ZXing.Net.Mobile.Android/ZXingTextureView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingTextureView.cs
@@ -1,0 +1,704 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Android.Content;
+using Android.Content.PM;
+using Android.Graphics;
+using Android.Hardware;
+using Android.OS;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+using Android.Widget;
+
+using ApxLabs.FastAndroidCamera;
+
+using Camera = Android.Hardware.Camera;
+
+namespace ZXing.Mobile
+{
+	public static class IntEx
+	{
+		public static bool Between(this int i, int lower, int upper)
+		{
+			return lower <= i && i <= upper;
+		}
+	}
+
+	public static class HandlerEx
+	{
+		public static void PostSafe(this Handler self, Action action)
+		{
+			self.Post(() =>
+			{
+				try
+				{
+					action();
+				}
+				catch (Exception ex)
+				{
+					// certain death, unless we squash
+					Log.Debug(MobileBarcodeScanner.TAG, $"Squashing: {ex} to avoid certain death! Handler is: {self.GetHashCode()}");
+				}
+			});
+		}
+
+		public static void PostSafe(this Handler self, Func<Task> action)
+		{
+			self.Post(async () =>
+			{
+				try
+				{
+					await action();
+				}
+				catch (Exception ex)
+				{
+					// certain death, unless we squash
+					Log.Debug(MobileBarcodeScanner.TAG, $"Squashing: {ex} to avoid certain death! Handler is: {self.GetHashCode()}");
+				}
+			});
+		}
+
+	}
+
+	public static class RectFEx {
+		public static void Flip(this RectF s) {
+			var tmp = s.Left;
+			s.Left = s.Top;
+			s.Top = tmp;
+			tmp = s.Right;
+			s.Right = s.Bottom;
+			s.Bottom = tmp;
+		}
+	}
+
+	class MyOrientationEventListener : OrientationEventListener
+	{
+		public MyOrientationEventListener(Context context, SensorDelay delay) : base(context, delay) { }
+
+		public event Action<int> OrientationChanged;
+
+		public override void OnOrientationChanged(int orientation)
+		{
+			OrientationChanged?.Invoke(orientation);
+		}
+	}
+
+	public class ZXingTextureView : TextureView, IScannerView, Camera.IAutoFocusCallback, INonMarshalingPreviewCallback
+	{
+		Camera.CameraInfo _cameraInfo;
+		Camera _camera;
+
+		static ZXingTextureView() {
+		}
+
+		public ZXingTextureView(IntPtr javaRef, JniHandleOwnership transfer) : base(javaRef, transfer)
+		{
+			Init();
+		}
+
+		public ZXingTextureView(Context ctx) : base(ctx)
+		{
+			Init();
+		}
+
+		public ZXingTextureView(Context ctx, IAttributeSet attr) : base(ctx, attr)
+		{
+			Init();
+		}
+
+		public ZXingTextureView(Context ctx, IAttributeSet attr, int defStyle) : base(ctx, attr, defStyle)
+		{
+			Init();
+		}
+
+		Toast _toast;
+		Handler _handler;
+		MyOrientationEventListener _orientationEventListener;
+		TaskCompletionSource<SurfaceTextureAvailableEventArgs> _surfaceAvailable = new TaskCompletionSource<SurfaceTextureAvailableEventArgs>();
+		void Init()
+		{
+			_toast = Toast.MakeText(Context, string.Empty, ToastLength.Short);
+
+			var handlerThread = new HandlerThread("ZXingTextureView");
+			handlerThread.Start();
+			_handler = new Handler(handlerThread.Looper);
+
+			// We have to handle changes to screen orientation explicitly, as we cannot rely on OnConfigurationChanges
+			_orientationEventListener = new MyOrientationEventListener(Context, SensorDelay.Normal);
+			_orientationEventListener.OrientationChanged += OnOrientationChanged;
+			if (_orientationEventListener.CanDetectOrientation())
+				_orientationEventListener.Enable();
+
+			SurfaceTextureAvailable += (sender, e) =>
+			{
+				_surfaceAvailable.SetResult(e);
+			};
+
+			SurfaceTextureSizeChanged += (sender, e) =>
+				SetSurfaceTransform(e.Surface, e.Width, e.Height);
+
+			SurfaceTextureDestroyed += (sender, e) =>
+			{
+				_surfaceAvailable = new TaskCompletionSource<SurfaceTextureAvailableEventArgs>();
+				ShutdownCamera();
+			};
+		}
+
+		Camera.Size PreviewSize { get; set; }
+
+		int _lastOrientation;
+		SurfaceOrientation _lastSurfaceOrientation;
+		void OnOrientationChanged(int orientation)
+		{
+			//
+			// This code should only run when UI snaps into either portrait or landscape mode.
+			// At first glance we could just override OnConfigurationChanged, but unfortunately 
+			// a rotation from landscape directly to reverse landscape won't fire an event 
+			// (which is easily done by rotating via upside-down on many devices), because Android
+			// can just reuse the existing config and handle the rotation automatically ..
+			// 
+			// .. except of course for camera orientation, which must handled explicitly *sigh*. 
+			// Hurray Google, you sure suck at API design!
+			//
+			// Instead we waste some CPU by tracking orientation down to the last degree, every 200ms.
+			// I have yet to come up with a better way. 
+			//
+			if (_camera == null)
+				return;
+
+			var o = (((orientation + 45) % 360) / 90) * 90; // snap to 0, 90, 180, or 270.
+			if (o == _lastOrientation)
+				return; // fast path, no change ..
+
+			// Actual snap is delayed, so check if we are actually rotated
+			var rotation = WindowManager.DefaultDisplay.Rotation;
+			if (rotation == _lastSurfaceOrientation)
+				return;  // .. still no change
+
+			_lastOrientation = o;
+			_lastSurfaceOrientation = rotation;
+
+			_handler.PostSafe(() =>
+			{
+				_camera?.SetDisplayOrientation(CameraOrientation(WindowManager.DefaultDisplay.Rotation)); // and finally, the interesting part *sigh*
+			});
+		}
+
+		bool IsPortrait { 
+			get { 			
+				var rotation = WindowManager.DefaultDisplay.Rotation;
+				return rotation == SurfaceOrientation.Rotation0 || rotation == SurfaceOrientation.Rotation180;
+			} 
+		}
+
+		Rectangle _area;
+		void SetSurfaceTransform(SurfaceTexture st, int width, int height)
+		{
+			using (var metrics = new DisplayMetrics())
+			{
+				#region transform
+				// Compensate for non-square pixels
+				WindowManager.DefaultDisplay.GetMetrics(metrics);
+				var aspectRatio = metrics.Xdpi / metrics.Ydpi; // close to 1, but rarely perfect 1
+
+				// Compensate for preview streams aspect ratio
+				var p = PreviewSize;
+				aspectRatio *= (float)p.Height / p.Width;
+
+				// Compensate for portrait mode
+				if (IsPortrait)
+					aspectRatio = 1f / aspectRatio;
+
+				// OpenGL coordinate system goes form 0 to 1
+				Matrix transform = new Matrix();
+				transform.SetScale(1f, aspectRatio * width / height); // lock on to width
+
+				Post(() => SetTransform(transform)); // ensure we use the right thread when updating transform
+
+				Log.Debug(MobileBarcodeScanner.TAG, $"Aspect ratio: {aspectRatio}, Transform: {transform}");
+
+				#endregion
+
+				#region area
+				using (var max = new RectF(0, 0, p.Width, p.Height))
+				using (var r = new RectF(max))
+				{
+					// Calculate area of interest within preview
+					var inverse = new Matrix();
+					transform.Invert(inverse);
+
+					Log.Debug(MobileBarcodeScanner.TAG, $"Inverse: {inverse}");
+
+					var flip = IsPortrait;
+					if (flip) r.Flip();
+					inverse.MapRect(r);
+					if (flip) r.Flip();
+
+					r.Intersect(max); // stream doesn't always fill the view!
+
+					// Compensate for reverse mounted camera, like on the Nexus 5X.
+					var reverse = _cameraInfo.Orientation == 270;
+					if (reverse)
+					{
+						if (flip)
+							r.OffsetTo(p.Width - r.Right, 0); // shift area right
+						else
+							r.Offset(0, p.Height - r.Bottom); // shift are down
+					}
+
+					_area = new Rectangle((int)r.Left, (int)r.Top, (int)r.Width(), (int)r.Height());
+
+					Log.Debug(MobileBarcodeScanner.TAG, $"Area: {_area}");
+				}
+				#endregion
+			}
+		}
+
+		IWindowManager _wm;
+		IWindowManager WindowManager
+		{
+			get
+			{
+				_wm = _wm ?? Context.GetSystemService(Context.WindowService).JavaCast<IWindowManager>();
+				return _wm;
+			}
+		}
+
+		bool? _hasTorch;
+		public bool HasTorch
+		{
+			get
+			{
+				if (_hasTorch.HasValue)
+					return _hasTorch.Value;
+
+				var p = _camera.GetParameters();
+				var supportedFlashModes = p.SupportedFlashModes;
+
+				if (supportedFlashModes != null
+					&& (supportedFlashModes.Contains(Camera.Parameters.FlashModeTorch)
+					|| supportedFlashModes.Contains(Camera.Parameters.FlashModeOn)))
+					_hasTorch = CheckTorchPermissions(false);
+
+				return _hasTorch.HasValue && _hasTorch.Value;
+			}
+		}
+
+		bool _isAnalyzing;
+		public bool IsAnalyzing
+		{
+			get { return _isAnalyzing; }
+		}
+
+		bool _isTorchOn;
+		public bool IsTorchOn
+		{
+			get { return _isTorchOn; }
+		}
+
+		MobileBarcodeScanningOptions _scanningOptions;
+		IBarcodeReaderGeneric<FastJavaByteArray> _barcodeReader;
+		public MobileBarcodeScanningOptions ScanningOptions
+		{
+			get { return _scanningOptions; }
+			set
+			{
+				_scanningOptions = value;
+				_barcodeReader = CreateBarcodeReader(value);
+			}
+		}
+
+		bool _useContinuousFocus;
+		bool _autoFocusRunning;
+		public void AutoFocus()
+		{
+			_handler.PostSafe(() =>
+			{
+				var camera = _camera;
+				if (camera == null || _autoFocusRunning || _useContinuousFocus)
+					return; // Allow camera to complete autofocus cycle, before trying again!
+
+				_autoFocusRunning = true;
+				camera.AutoFocus(this);
+			});
+		}
+
+		public void AutoFocus(int x, int y)
+		{
+			// todo: Needs some slightly serious math to map back to camera coordinates. 
+			// The method used in ZXingSurfaceView is simply wrong.
+			AutoFocus();
+		}
+
+		public void OnAutoFocus(bool focus, Camera camera)
+		{
+			_autoFocusRunning = false;
+			if (!(focus || _useContinuousFocus))
+				AutoFocus();
+		}
+
+
+		public void PauseAnalysis()
+		{
+			_isAnalyzing = false;
+		}
+
+		public void ResumeAnalysis()
+		{
+			_isAnalyzing = true;
+		}
+
+		Action<Result> _callback;
+		public void StartScanning(Action<Result> scanResultCallback, MobileBarcodeScanningOptions options = null)
+		{
+			_callback = scanResultCallback;
+			ScanningOptions = options ?? MobileBarcodeScanningOptions.Default;
+
+			_handler.PostSafe(SetupCamera);
+
+			ResumeAnalysis();
+		}
+
+		void OpenCamera()
+		{
+			if (_camera != null)
+				return;
+
+			CheckCameraPermissions();
+
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.Gingerbread) // Choose among multiple cameras from Gingerbread forward
+			{
+				int max = Camera.NumberOfCameras;
+				Log.Debug(MobileBarcodeScanner.TAG, $"Found {max} cameras");
+				var requestedFacing = CameraFacing.Back; // default to back facing camera, ..
+				if (ScanningOptions.UseFrontCameraIfAvailable.HasValue && ScanningOptions.UseFrontCameraIfAvailable.Value)
+					requestedFacing = CameraFacing.Front; // .. but use front facing if available and requested
+
+				var info = new Camera.CameraInfo();
+				int idx = 0;
+				do
+				{
+					Camera.GetCameraInfo(idx++, info); // once again Android sucks!
+				}
+				while (info.Facing != requestedFacing && idx < max);
+				--idx;
+
+				Log.Debug(MobileBarcodeScanner.TAG, $"Opening {info.Facing} facing camera: {idx}...");
+				_cameraInfo = info;
+				_camera = Camera.Open(idx);
+			}
+			else {
+				_camera = Camera.Open();
+			}
+
+			_camera.Lock();
+		}
+
+		async Task SetupCamera()
+		{
+			OpenCamera();
+
+			var p = _camera.GetParameters();
+			p.PreviewFormat = ImageFormatType.Nv21; // YCrCb format (all Android devices must support this)
+
+			// First try continuous video, then auto focus, then fixed
+			var supportedFocusModes = p.SupportedFocusModes;
+			if (supportedFocusModes.Contains(Camera.Parameters.FocusModeContinuousVideo))
+				p.FocusMode = Camera.Parameters.FocusModeContinuousVideo;
+			else if (supportedFocusModes.Contains(Camera.Parameters.FocusModeAuto))
+				p.FocusMode = Camera.Parameters.FocusModeAuto;
+			else if (supportedFocusModes.Contains(Camera.Parameters.FocusModeFixed))
+				p.FocusMode = Camera.Parameters.FocusModeFixed;
+
+			// Check if we can support requested resolution ..
+			var availableResolutions = p.SupportedPreviewSizes.Select(s => new CameraResolution { Width = s.Width, Height = s.Height }).ToList();
+			var resolution = ScanningOptions.GetResolution(availableResolutions);
+
+			// .. If not, let's try and find a suitable one
+			resolution = resolution ?? availableResolutions.OrderBy(r => r.Width).FirstOrDefault(r => r.Width.Between(640, 1280) && r.Height.Between(640, 960));
+
+			// Hopefully a resolution was selected at some point
+			if (resolution != null)
+				p.SetPreviewSize(resolution.Width, resolution.Height);
+
+			_camera.SetParameters(p);
+
+			SetupTorch(_isTorchOn);
+
+			p = _camera.GetParameters(); // refresh!
+
+			_useContinuousFocus = p.FocusMode == Camera.Parameters.FocusModeContinuousVideo;
+			PreviewSize = p.PreviewSize; // get actual preview size (may differ from requested size)
+			var bitsPerPixel = ImageFormat.GetBitsPerPixel(p.PreviewFormat);
+
+			Log.Debug(MobileBarcodeScanner.TAG, $"Preview size {PreviewSize.Width}x{PreviewSize.Height} with {bitsPerPixel} bits per pixel");
+
+			var surfaceInfo = await _surfaceAvailable.Task;
+			SetSurfaceTransform(surfaceInfo.Surface, surfaceInfo.Width, surfaceInfo.Height);
+
+			_camera.SetDisplayOrientation(CameraOrientation(WindowManager.DefaultDisplay.Rotation));
+			_camera.SetPreviewTexture(surfaceInfo.Surface);
+			_camera.StartPreview();
+
+			int bufferSize = (PreviewSize.Width * PreviewSize.Height * bitsPerPixel) / 8;
+			using (var buffer = new FastJavaByteArray(bufferSize))
+				_camera.AddCallbackBuffer(buffer);
+
+			_camera.SetNonMarshalingPreviewCallback(this);
+
+			// Docs suggest if Auto or Macro modes, we should invoke AutoFocus at least once
+			_autoFocusRunning = false;
+			if (!_useContinuousFocus)
+				AutoFocus();
+		}
+
+		public int CameraOrientation(SurfaceOrientation rotation)
+		{
+			int degrees = 0;
+			switch (rotation)
+			{
+				case SurfaceOrientation.Rotation0:
+					degrees = 0;
+					break;
+				case SurfaceOrientation.Rotation90:
+					degrees = 90;
+					break;
+				case SurfaceOrientation.Rotation180:
+					degrees = 180;
+					break;
+				case SurfaceOrientation.Rotation270:
+					degrees = 270;
+					break;
+			}
+
+			// Handle front facing camera
+			if (_cameraInfo.Facing == CameraFacing.Front)
+				return (360 - ((_cameraInfo.Orientation + degrees) % 360)) % 360;  // compensate for mirror
+
+			return (_cameraInfo.Orientation - degrees + 360) % 360;
+		}
+
+		void ShutdownCamera()
+		{
+			_handler.Post(() =>
+			{
+				if (_camera == null)
+					return;
+
+				var camera = _camera;
+				_camera = null;
+
+				try
+				{
+					camera.StopPreview();
+					camera.SetNonMarshalingPreviewCallback(null);
+				}
+				catch (Exception e)
+				{
+					Log.Error(MobileBarcodeScanner.TAG, e.ToString());
+				}
+				finally
+				{
+					camera.Release();
+				}
+			});
+		}
+
+		public void StopScanning()
+		{
+			PauseAnalysis();
+			ShutdownCamera();
+		}
+
+		public void Torch(bool on)
+		{
+			if (!Context.PackageManager.HasSystemFeature(PackageManager.FeatureCameraFlash))
+			{
+				Log.Info(MobileBarcodeScanner.TAG, "Flash not supported on this device");
+				return;
+			}
+
+			CheckTorchPermissions();
+
+			_isTorchOn = on;
+			if (_camera != null) // already running
+				SetupTorch(on);
+		}
+
+		public void ToggleTorch()
+		{
+			Torch(!_isTorchOn);
+		}
+
+		void SetupTorch(bool on)
+		{
+			var p = _camera.GetParameters();
+			var supportedFlashModes = p.SupportedFlashModes ?? Enumerable.Empty<string>();
+
+			string flashMode = null;
+
+			if (on)
+			{
+				if (supportedFlashModes.Contains(Camera.Parameters.FlashModeTorch))
+					flashMode = Camera.Parameters.FlashModeTorch;
+				else if (supportedFlashModes.Contains(Camera.Parameters.FlashModeOn))
+					flashMode = Camera.Parameters.FlashModeOn;
+			}
+			else
+			{
+				if (supportedFlashModes.Contains(Camera.Parameters.FlashModeOff))
+					flashMode = Camera.Parameters.FlashModeOff;
+			}
+
+			if (!string.IsNullOrEmpty(flashMode))
+			{
+				p.FlashMode = flashMode;
+				_camera.SetParameters(p);
+			}
+		}
+
+		bool CheckCameraPermissions(bool throwOnError = true)
+		{
+			return CheckPermissions(Android.Manifest.Permission.Camera, throwOnError);
+		}
+
+		bool CheckTorchPermissions(bool throwOnError = true)
+		{
+			return CheckPermissions(Android.Manifest.Permission.Flashlight, throwOnError);
+		}
+
+		bool CheckPermissions(string permission, bool throwOnError = true)
+		{
+			Log.Debug(MobileBarcodeScanner.TAG, $"Checking {permission}...");
+
+			if (!PlatformChecks.IsPermissionInManifest(Context, permission)
+				|| !PlatformChecks.IsPermissionGranted(Context, permission))
+			{
+				var msg = $"Requires: {permission}, but was not found in your AndroidManifest.xml file.";
+				Log.Error(MobileBarcodeScanner.TAG, msg);
+
+				if (throwOnError)
+					throw new UnauthorizedAccessException(msg);
+
+				return false;
+			}
+
+			return true;
+		}
+
+		IBarcodeReaderGeneric<FastJavaByteArray> CreateBarcodeReader(MobileBarcodeScanningOptions options)
+		{
+			var barcodeReader = new BarcodeReaderGeneric<FastJavaByteArray>();
+
+			if (options.TryHarder.HasValue)
+				barcodeReader.Options.TryHarder = options.TryHarder.Value;
+
+			if (options.PureBarcode.HasValue)
+				barcodeReader.Options.PureBarcode = options.PureBarcode.Value;
+
+			if (!string.IsNullOrEmpty(options.CharacterSet))
+				barcodeReader.Options.CharacterSet = options.CharacterSet;
+
+			if (options.TryInverted.HasValue)
+				barcodeReader.TryInverted = options.TryInverted.Value;
+
+			if (options.AutoRotate.HasValue)
+				barcodeReader.AutoRotate = options.AutoRotate.Value;
+
+			if (options.PossibleFormats?.Any() ?? false)
+			{
+				barcodeReader.Options.PossibleFormats = new List<BarcodeFormat>();
+
+				foreach (var pf in options.PossibleFormats)
+					barcodeReader.Options.PossibleFormats.Add(pf);
+			}
+
+			return barcodeReader;
+		}
+
+		public void RotateCounterClockwise(byte[] source, ref byte[] target, int width, int height)
+		{
+			if (source.Length != (target?.Length ?? -1))
+				target = new byte[source.Length];
+
+			for (int y = 0; y < height; y++)
+				for (int x = 0; x < width; x++)
+					target[x * height + height - y - 1] = source[x + y * width];
+		}
+
+		byte[] _matrix;
+		byte[] _rotatedMatrix;
+		Result _lastResult;
+		async public void OnPreviewFrame(IntPtr data, Camera camera)
+		{
+			System.Diagnostics.Stopwatch sw = null;
+			using (var buffer = new FastJavaByteArray(data)) // avoids marshalling
+			{ 
+				try
+				{
+#if DEBUG
+					sw = new System.Diagnostics.Stopwatch();
+					sw.Start();
+#endif
+					if (!_isAnalyzing)
+						return;
+
+					var isPortrait = IsPortrait;
+
+					var result = await Task.Run(() =>
+					{
+						LuminanceSource luminanceSource;
+						var fast = new FastJavaByteArrayYUVLuminanceSource(buffer, PreviewSize.Width, PreviewSize.Height, _area.Left, _area.Top, _area.Width, _area.Height);
+						if (isPortrait)
+						{
+							fast.CopyMatrix(ref _matrix);
+							RotateCounterClockwise(_matrix, ref _rotatedMatrix, _area.Width, _area.Height);
+							luminanceSource = new PlanarYUVLuminanceSource(_rotatedMatrix, _area.Height, _area.Width, 0, 0, _area.Height, _area.Width, false);
+						}
+						else
+							luminanceSource = fast;
+
+						return _barcodeReader.Decode(luminanceSource);
+					});
+
+					if (result != null)
+					{
+						// don't raise the same barcode multiple times, unless we have seen atleast one other barcode or an empty frame
+						if (result.Text != _lastResult?.Text)
+							_callback(result);
+					}
+					else if (!_useContinuousFocus)
+						AutoFocus();
+
+					_lastResult = result;
+				}
+				catch (Exception ex)
+				{
+					// It is better to just skip a frame :-) ..
+					Log.Warn(MobileBarcodeScanner.TAG, ex.ToString());
+				}
+				finally
+				{
+					camera.AddCallbackBuffer(buffer); // IMPORTANT!
+
+#if DEBUG
+					sw.Stop();
+					try
+					{
+						Post(() =>
+						{
+							_toast.SetText(string.Format("{0}ms", sw.ElapsedMilliseconds));
+							_toast.Show();
+						});
+					}
+					catch { } // squash
+#endif
+				}
+			}
+		}
+	}
+}

--- a/Source/ZXing.Net.Mobile.Core/Performance.cs
+++ b/Source/ZXing.Net.Mobile.Core/Performance.cs
@@ -43,8 +43,7 @@ namespace ZXing.Mobile
 				msg += " {0}";
 
 			if (Debugger.IsAttached)
-				System.Diagnostics.Debug.WriteLine (msg, elapsed.TotalMilliseconds);
+				Debug.WriteLine (msg, elapsed.TotalMilliseconds);
 		}
 	}
-
 }

--- a/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
+++ b/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
@@ -1,24 +1,24 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+using Android.App;
+using Android.Runtime;
+using Android.Views;
+
 using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+using ZXing.Mobile;
 using ZXing.Net.Mobile.Forms;
 using ZXing.Net.Mobile.Forms.Android;
-using Android.Runtime;
-using Android.App;
-using Xamarin.Forms.Platform.Android;
-using Android.Views;
-using System.ComponentModel;
-using System.Reflection;
-using Android.Widget;
-using ZXing.Mobile;
-using System.Threading.Tasks;
-using System.Linq.Expressions;
 
-[assembly:ExportRenderer(typeof(ZXingScannerView), typeof(ZXingScannerViewRenderer))]
+[assembly: ExportRenderer(typeof(ZXingScannerView), typeof(ZXingScannerViewRenderer))]
 namespace ZXing.Net.Mobile.Forms.Android
 {
-    [Preserve(AllMembers = true)]
-    public class ZXingScannerViewRenderer : ViewRenderer<ZXingScannerView, ZXing.Mobile.ZXingSurfaceView>
-    {       
+	[Preserve(AllMembers = true)]
+	public class ZXingScannerViewRenderer : ViewRenderer<ZXingScannerView, ZXing.Mobile.ZXingTextureView>
+	{       
         public ZXingScannerViewRenderer () : base ()
         {
         }
@@ -31,8 +31,8 @@ namespace ZXing.Net.Mobile.Forms.Android
 
         protected ZXingScannerView formsView;
 
-        protected ZXingSurfaceView zxingSurface;
-        internal Task<bool> requestPermissionsTask;
+		protected ZXingTextureView zxingTexture;
+		internal Task<bool> requestPermissionsTask;
 
         protected override async void OnElementChanged(ElementChangedEventArgs<ZXingScannerView> e)
         {
@@ -40,15 +40,15 @@ namespace ZXing.Net.Mobile.Forms.Android
 
             formsView = Element;
 
-            if (zxingSurface == null) {
+            if (zxingTexture == null) {
 
                 // Process requests for autofocus
                 formsView.AutoFocusRequested += (x, y) => {
-                    if (zxingSurface != null) {
+                    if (zxingTexture != null) {
                         if (x < 0 && y < 0)
-                            zxingSurface.AutoFocus ();
+                            zxingTexture.AutoFocus ();
                         else
-                            zxingSurface.AutoFocus (x, y);
+                            zxingTexture.AutoFocus (x, y);
                     }
                 };
 
@@ -56,20 +56,21 @@ namespace ZXing.Net.Mobile.Forms.Android
 
                 if (activity != null)                
                     await PermissionsHandler.RequestPermissions (activity);
-                
-                zxingSurface = new ZXingSurfaceView (Xamarin.Forms.Forms.Context as Activity, formsView.Options);
-                zxingSurface.LayoutParameters = new LayoutParams (LayoutParams.MatchParent, LayoutParams.MatchParent);
 
-                base.SetNativeControl (zxingSurface);
+				// zxingSurface = new ZXingSurfaceView (Xamarin.Forms.Forms.Context as Activity, formsView.Options);
+				zxingTexture = new ZXingTextureView(Xamarin.Forms.Forms.Context);
+				zxingTexture.LayoutParameters = new LayoutParams (LayoutParams.MatchParent, LayoutParams.MatchParent);
+
+                base.SetNativeControl (zxingTexture);
 
                 if (formsView.IsScanning)
-                    zxingSurface.StartScanning(formsView.RaiseScanResult, formsView.Options);
+                    zxingTexture.StartScanning(formsView.RaiseScanResult, formsView.Options);
 
                 if (!formsView.IsAnalyzing)
-                    zxingSurface.PauseAnalysis ();
+                    zxingTexture.PauseAnalysis ();
 
                 if (formsView.IsTorchOn)
-                    zxingSurface.Torch (true);
+                    zxingTexture.Torch (true);
             }
         }
 
@@ -77,24 +78,24 @@ namespace ZXing.Net.Mobile.Forms.Android
         {
             base.OnElementPropertyChanged (sender, e);
 
-            if (zxingSurface == null)
+            if (zxingTexture == null)
                 return;
             
             switch (e.PropertyName) {
             case nameof (ZXingScannerView.IsTorchOn):
-                zxingSurface.Torch (formsView.IsTorchOn);
+                zxingTexture.Torch (formsView.IsTorchOn);
                 break;
             case nameof (ZXingScannerView.IsScanning):
                 if (formsView.IsScanning)
-                    zxingSurface.StartScanning (formsView.RaiseScanResult, formsView.Options);
+                    zxingTexture.StartScanning (formsView.RaiseScanResult, formsView.Options);
                 else
-                    zxingSurface.StopScanning ();
+                    zxingTexture.StopScanning ();
                 break;
             case nameof (ZXingScannerView.IsAnalyzing):
                 if (formsView.IsAnalyzing)
-                    zxingSurface.ResumeAnalysis ();
+                    zxingTexture.ResumeAnalysis ();
                 else
-                    zxingSurface.PauseAnalysis ();
+                    zxingTexture.PauseAnalysis ();
                 break;
             } 
         }
@@ -104,8 +105,8 @@ namespace ZXing.Net.Mobile.Forms.Android
             var x = e.GetX ();            
             var y = e.GetY ();
 
-            if (zxingSurface != null) {
-                zxingSurface.AutoFocus ((int)x, (int)y);
+            if (zxingTexture != null) {
+                zxingTexture.AutoFocus ((int)x, (int)y);
                 System.Diagnostics.Debug.WriteLine ("Touch: x={0}, y={1}", x, y);
             }
             return base.OnTouchEvent (e);

--- a/Source/ZXing.Net.Mobile.Forms/ZXingScannerView.cs
+++ b/Source/ZXing.Net.Mobile.Forms/ZXingScannerView.cs
@@ -72,7 +72,7 @@ namespace ZXing.Net.Mobile.Forms
         }
 
         public static readonly BindableProperty IsAnalyzingProperty =
-            BindableProperty.Create( nameof( IsAnalyzing ), typeof( bool ), typeof( ZXingScannerView ), false );
+            BindableProperty.Create( nameof( IsAnalyzing ), typeof( bool ), typeof( ZXingScannerView ), true );
 
         public bool IsAnalyzing {
             get { return (bool)GetValue (IsAnalyzingProperty); }


### PR DESCRIPTION
Compared to existing ZXingSurfaceView, ZXingTextureView fixes the following:

- Ensure correct aspect ratio, no matter what the view size.
- Use background handler for all camera manipulation.
- Crop preview to match viewfinder, so that you only scan what you see.
- Avoid byte[] marshalling between Java and .Net runtime (FastJavaByteArray).
- Return buffer to java runtime with camera.AddCallbackBuffer.
- Avoid traslating from YCrCb to Rgb and back to luminance data (FastJavaByteArrayYUVLuminanceSource)
- Re-use buffers, to avoid memory pressure, when rotating.
- Automatically request autofocus on devices that does not support continous auto focus mode.
- Prefer continous mode
- For Xamarin.Forms ZXingScannerView now uses ZXingTextureView in the renderer on Android.