### PR TITLE
iOS: Use raw pointer to CVPixelBuffer for decoding

### DIFF
--- a/Source/ZXing.Net.Mobile.iOS/CVPixelBufferARGB32LuminanceSource.cs
+++ b/Source/ZXing.Net.Mobile.iOS/CVPixelBufferARGB32LuminanceSource.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using CoreVideo;
+using ZXing;
+
+namespace ZXing.Mobile
+{
+    public class CVPixelBufferARGB32LuminanceSource : BaseLuminanceSource
+    {
+        public unsafe CVPixelBufferARGB32LuminanceSource(byte* cvPixelByteArray, int cvPixelByteArrayLength, int width, int height)
+            : base(width, height)
+        {
+            CalculateLuminance(cvPixelByteArray, cvPixelByteArrayLength);
+        }
+
+        unsafe void CalculateLuminance(byte* rgbRawBytes, int bytesLen)
+        {
+            for (int rgbIndex = 0, luminanceIndex = 0; rgbIndex < bytesLen && luminanceIndex < luminances.Length; luminanceIndex++)
+            {
+                // Calculate luminance cheaply, favoring green.
+                var b = rgbRawBytes[rgbIndex++];
+                var g = rgbRawBytes[rgbIndex++];
+                var r = rgbRawBytes[rgbIndex++];
+                var alpha = rgbRawBytes[rgbIndex++];
+                var luminance = (byte)((RChannelWeight * r + GChannelWeight * g + BChannelWeight * b) >> ChannelWeight);
+                luminances[luminanceIndex] = (byte)(((luminance * alpha) >> 8) + (255 * (255 - alpha) >> 8));
+            }
+        }
+
+        protected override LuminanceSource CreateLuminanceSource(byte[] newLuminances, int width, int height)
+        {
+            return new ZXing.RGBLuminanceSource (luminances, width, height, RGBLuminanceSource.BitmapFormat.ARGB32);
+        }
+    }
+}

--- a/Source/ZXing.Net.Mobile.iOS/ZXing.Net.Mobile.iOS.csproj
+++ b/Source/ZXing.Net.Mobile.iOS/ZXing.Net.Mobile.iOS.csproj
@@ -21,6 +21,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>True</MtouchDebug>
     <IntermediateOutputPath>obj\unified\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -31,29 +32,33 @@
     <ConsolePause>False</ConsolePause>
     <MtouchLink>None</MtouchLink>
     <IntermediateOutputPath>obj\unified\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>..\..\Build\Debug\ios-unified\</OutputPath>
-    <DefineConstants>DEBUG</DefineConstants>
+    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>True</MtouchDebug>
     <IntermediateOutputPath>obj\unified\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>..\..\Build\Release\ios-unified\</OutputPath>
+    <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <IntermediateOutputPath>obj\unified\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>ZXingNetMobile</AssemblyName>
@@ -78,6 +83,7 @@
     <Compile Include="ZXingDefaultOverlayView.cs" />
     <Compile Include="ZXingScannerView.cs" />
     <Compile Include="ZXingScannerViewController.cs" />
+    <Compile Include="CVPixelBufferARGB32LuminanceSource.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>


### PR DESCRIPTION
Huge performance gain by creating a luminance source using unsafe access to the raw CVPixelBuffer pointer