### PR TITLE
Fix for a null reference exception

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -40,6 +40,9 @@ namespace ZXing.Mobile
 
         async void displayInformation_OrientationChanged(DisplayInformation sender, object args)
         {
+            //This safeguards against a null reference if the device is rotated *before* the first call to StartScanning
+            if (mediaCapture == null) return;
+
             displayOrientation = sender.CurrentOrientation;
             var props = mediaCapture.VideoDeviceController.GetMediaStreamProperties(MediaStreamType.VideoPreview);
             await SetPreviewRotationAsync(props);


### PR DESCRIPTION
There's currently a bug around rotating in UWP -  due to the fact that the control subscribes to DeviceOrientation at construction, but only instantiates mediaControl when StartScanning is called for the first time, you can enter into a state where the control itself is instantiated due to the XAML tree being built out, but the scanner hasn't started yet.  In these circumstances, rotating the device will cause a hard crash due to the null reference.