### PR TITLE
Fix for AutoFocus crash before the MediaCapture initialize.

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -357,6 +357,7 @@ namespace ZXing.Mobile
             get
             {
                 return mediaCapture != null
+                    && isMediaCaptureInitialized
                     && mediaCapture.VideoDeviceController != null
                     && mediaCapture.VideoDeviceController.FocusControl != null
                     && mediaCapture.VideoDeviceController.FocusControl.Supported;


### PR DESCRIPTION
Fix #449