### PR TITLE
Fix missing RootFrame

### DIFF
--- a/Samples/WindowsUniversal/Sample.WindowsUniversal/MainPage.xaml.cs
+++ b/Samples/WindowsUniversal/Sample.WindowsUniversal/MainPage.xaml.cs
@@ -34,7 +34,7 @@ namespace Sample.WindowsUniversal
 
             //Create a new instance of our scanner
             scanner = new MobileBarcodeScanner(this.Dispatcher);
-            scanner.Dispatcher = this.Dispatcher;
+            scanner.RootFrame = this.Frame;
         }
 
         private void buttonScanDefault_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
I used the Nuget package version 2.1.47. Not setting the root frame caused a NullReferenceException.