### PR TITLE
Fix Forms default overlay bindings

### DIFF
--- a/Source/ZXing.Net.Mobile.Forms.Android/ZXing.Net.Mobile.Forms.Android.csproj
+++ b/Source/ZXing.Net.Mobile.Forms.Android/ZXing.Net.Mobile.Forms.Android.csproj
@@ -89,6 +89,9 @@
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Forms.2.3.3.193\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
+    <Reference Include="FastAndroidCamera">
+      <HintPath>..\..\Samples\Forms\packages\FastAndroidCamera.2.0.0\lib\MonoAndroid403\FastAndroidCamera.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/ZXing.Net.Mobile.Forms.Android/packages.config
+++ b/Source/ZXing.Net.Mobile.Forms.Android/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FastAndroidCamera" version="2.0.0" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid60" />

--- a/Source/ZXing.Net.Mobile.Forms/ZXingDefaultOverlay.cs
+++ b/Source/ZXing.Net.Mobile.Forms/ZXingDefaultOverlay.cs
@@ -15,6 +15,8 @@ namespace ZXing.Net.Mobile.Forms
            
         public ZXingDefaultOverlay ()
         {
+			BindingContext = this;
+
             VerticalOptions = LayoutOptions.FillAndExpand;
             HorizontalOptions = LayoutOptions.FillAndExpand;
 

--- a/ZXing.Net.Mobile.Forms.nuspec
+++ b/ZXing.Net.Mobile.Forms.nuspec
@@ -9,7 +9,11 @@
         <projectUrl>http://github.com/Redth/ZXing.Net.Mobile</projectUrl>
         <iconUrl>http://raw.github.com/Redth/ZXing.Net.Mobile/master/Art/ZXing.Net.Mobile-Icon.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>ZXing.Net.Mobile is a C#/.NET library based on the open source Barcode Library: ZXing (Zebra Crossing), using the ZXing.Net Port. It works with Xamarin.iOS, Xamarin.Android, Windows Phone (Silverlight), and Windows Universal. The goal of ZXing.Net.Mobile is to make scanning barcodes as effortless and painless as possible in your own applications.</description>
+        <description>
+            ZXing.Net.Mobile is a C#/.NET library based on the open source Barcode Library: ZXing (Zebra Crossing), using the ZXing.Net Port. It works with Xamarin.iOS, Xamarin.Android, Windows Phone (Silverlight), and Windows Universal. The goal of ZXing.Net.Mobile is to make scanning barcodes as effortless and painless as possible in your own applications.
+            
+            See https://github.com/Redth/ZXing.Net.Mobile/releases for release notes.
+        </description>
         <summary>ZXing Barcode Scanning for your Xamarin.iOS, Xamarin.Android, Windows Phone (Silverlight), and Windows Universal apps!</summary>
         <copyright />
         <tags>barcode, zxing, zxing.net, qr, scan, scanning, scanner</tags>

--- a/ZXing.Net.Mobile.nuspec
+++ b/ZXing.Net.Mobile.nuspec
@@ -9,7 +9,11 @@
         <projectUrl>http://github.com/Redth/ZXing.Net.Mobile</projectUrl>
         <iconUrl>http://raw.github.com/Redth/ZXing.Net.Mobile/master/Art/ZXing.Net.Mobile-Icon.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>ZXing.Net.Mobile is a C#/.NET library based on the open source Barcode Library: ZXing (Zebra Crossing), using the ZXing.Net Port. It works with Xamarin.iOS, Xamarin.Android, Windows Phone (Silverlight) and Windows Universal. The goal of ZXing.Net.Mobile is to make scanning barcodes as effortless and painless as possible in your own applications.</description>
+        <description>
+            ZXing.Net.Mobile is a C#/.NET library based on the open source Barcode Library: ZXing (Zebra Crossing), using the ZXing.Net Port. It works with Xamarin.iOS, Xamarin.Android, Windows Phone (Silverlight) and Windows Universal. The goal of ZXing.Net.Mobile is to make scanning barcodes as effortless and painless as possible in your own applications.
+
+            See https://github.com/Redth/ZXing.Net.Mobile/releases for release notes.
+        </description>
         <summary>ZXing Barcode Scanning for your Xamarin.iOS, Xamarin.Android, Windows Phone (Silverlight) and Windows Universal apps!</summary>
         <copyright />
         <tags>barcode, zxing, zxing.net, qr, scan, scanning, scanner</tags>


### PR DESCRIPTION
The binding context of the `ZXingDefaultOverlay` view was never set, so any attempts to change the visibility of the flash button or set the top/bottom text would cause it to not be visible, basically the bindings weren’t propagating.

Also some minor other fixes (Forms android should reference FastAndroidCamera directly).