### PR TITLE
Added event when camera initialized

### DIFF
--- a/Source/ZXing.Net.Mobile.WindowsUniversal/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/MobileBarcodeScanner.cs
@@ -60,7 +60,7 @@ namespace ZXing.Mobile
                     },
                     Scanner = this,
                     ContinuousScanning = false,
-                    CameraInitialized = () => { OnCameraInitialized.Invoke(); }
+                    CameraInitialized = () => { OnCameraInitialized?.Invoke(); }
                 };
                 rootFrame.Navigate(typeof(ScanPage), pageOptions);
             });

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/MobileBarcodeScanner.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/MobileBarcodeScanner.cs
@@ -51,7 +51,7 @@ namespace ZXing.Mobile
 
             await dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                rootFrame.Navigate(typeof(ScanPage), new ScanPageNavigationParameters
+                var pageOptions = new ScanPageNavigationParameters
                 {
                     Options = options,
                     ResultHandler = r =>
@@ -59,8 +59,10 @@ namespace ZXing.Mobile
                         tcsScanResult.SetResult(r);
                     },
                     Scanner = this,
-                    ContinuousScanning = false
-                });
+                    ContinuousScanning = false,
+                    CameraInitialized = () => { OnCameraInitialized.Invoke(); }
+                };
+                rootFrame.Navigate(typeof(ScanPage), pageOptions);
             });
             
             var result = await tcsScanResult.Task;
@@ -73,6 +75,10 @@ namespace ZXing.Mobile
 
             return result;
         }
+
+        public event ScannerOpened OnCameraInitialized;
+        public delegate void ScannerOpened();
+
 
         public override async void Cancel()
         {

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ScanPage.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ScanPage.xaml.cs
@@ -61,7 +61,7 @@ namespace ZXing.Mobile
 
         private void ScannerControl_OnCameraInitialized()
         {
-            Parameters.CameraInitialized.Invoke();
+            Parameters.CameraInitialized?.Invoke();
         }
 
         protected override async void OnNavigatingFrom(NavigatingCancelEventArgs e)

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ScanPage.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ScanPage.xaml.cs
@@ -42,6 +42,8 @@ namespace ZXing.Mobile
 
             Parameters = e.Parameter as ScanPageNavigationParameters;
 
+            scannerControl.OnCameraInitialized += ScannerControl_OnCameraInitialized;
+
             if (Parameters != null)
                 Parameters.Scanner.ScanPage = this;
             
@@ -56,7 +58,12 @@ namespace ZXing.Mobile
 
             scannerControl.StartScanning(Parameters?.ResultHandler, Parameters?.Options);
         }
-        
+
+        private void ScannerControl_OnCameraInitialized()
+        {
+            Parameters.CameraInitialized.Invoke();
+        }
+
         protected override async void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             try
@@ -183,5 +190,8 @@ namespace ZXing.Mobile
         public bool ContinuousScanning { get; set; }
         public MobileBarcodeScanningOptions Options { get; set; }
         public Action<ZXing.Result> ResultHandler { get; set; }
+
+        public Action CameraInitialized { get; set; }
+        
     }
 }

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -173,9 +173,14 @@ namespace ZXing.Mobile
             // Set the capture element's source to show it in the UI
             captureElement.Source = mediaCapture;
 
+            
             // Start the preview
             await mediaCapture.StartPreviewAsync();
-
+            // If camera begins streaming invoke OnCameraInitialized
+            if (mediaCapture.CameraStreamState == CameraStreamState.Streaming)
+            {
+                OnCameraInitialized.Invoke();
+            }
 
             // Get all the available resolutions for preview
             var availableProperties = mediaCapture.VideoDeviceController.GetAvailableMediaStreamProperties(MediaStreamType.VideoPreview);
@@ -295,6 +300,10 @@ namespace ZXing.Mobile
                          
             }, null, ScanningOptions.InitialDelayBeforeAnalyzingFrames, Timeout.Infinite);
         }
+
+        public event ScannerOpened OnCameraInitialized;
+        public delegate void ScannerOpened();
+
 
         async Task<DeviceInformation> GetFilteredCameraOrDefaultAsync(MobileBarcodeScanningOptions options)
         {

--- a/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
+++ b/Source/ZXing.Net.Mobile.WindowsUniversal/ZXingScannerControl.xaml.cs
@@ -179,7 +179,8 @@ namespace ZXing.Mobile
             // If camera begins streaming invoke OnCameraInitialized
             if (mediaCapture.CameraStreamState == CameraStreamState.Streaming)
             {
-                OnCameraInitialized.Invoke();
+                if(OnCameraInitialized != null)
+                    OnCameraInitialized.Invoke();
             }
 
             // Get all the available resolutions for preview
@@ -441,7 +442,7 @@ namespace ZXing.Mobile
 
         public async Task AutoFocusAsync(int x, int y, bool useCoordinates)
         {
-            if (IsFocusSupported)
+            if (IsFocusSupported && mediaCapture.CameraStreamState == CameraStreamState.Streaming)
             {
                 var focusControl = mediaCapture.VideoDeviceController.FocusControl;
                 var roiControl = mediaCapture.VideoDeviceController.RegionsOfInterestControl;
@@ -488,7 +489,7 @@ namespace ZXing.Mobile
                             await roiControl.ClearRegionsAsync();
                         }
                     }
-
+                    
                     await focusControl.FocusAsync();
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Hello!

I'm using your library and it's fantastic! But I've got some problems on weak devices when camera wasn't initialized (if user presses screen, before camera initialized it throws). So I've added event, and now I can subscribe on camera initialization and prevent any user input before initialization complete.