### PR TITLE
Fix DelayBetweenContinuousScans in iOS

### DIFF
--- a/Source/ZXing.Net.Mobile.iOS/ZXingScannerView.cs
+++ b/Source/ZXing.Net.Mobile.iOS/ZXingScannerView.cs
@@ -543,7 +543,8 @@ namespace ZXing.Mobile
                             luminanceSource = new CVPixelBufferARGB32LuminanceSource(rawData, rawDatalen, (int)pixelBuffer.Width, (int)pixelBuffer.Height);
                         }
 
-                        HandleImage(luminanceSource);
+                        if (HandleImage(luminanceSource))
+                            wasScanned = true;
 
                         pixelBuffer.Unlock(CVPixelBufferLock.ReadOnly);
                     }
@@ -560,8 +561,11 @@ namespace ZXing.Mobile
 				} catch (Exception e){
 					Console.WriteLine (e);
 				}
+                finally
+                {
+                    working = false;
+                }
 
-				working = false;
 			}
 		}
 	
@@ -735,4 +739,3 @@ namespace ZXing.Mobile
 		#endregion
 	}
 }
-


### PR DESCRIPTION
Restored logic for wasScanned variable. Also added finally statement around decoding of image to set working to false even if an exception occurs (that would effectively stop analyzing forever).

Resolves issue DelayBetweenContinuousScans does not work on iOS #548.