### PR TITLE
Fix for scanning not active on custom scan page after camera permissi…

### DIFF
--- a/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
+++ b/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
@@ -65,9 +65,6 @@ namespace ZXing.Net.Mobile.Forms.Android
                 if (formsView.IsScanning)
                     zxingSurface.StartScanning(formsView.RaiseScanResult, formsView.Options);
 
-                if (!formsView.IsAnalyzing)
-                    zxingSurface.PauseAnalysis ();
-
                 if (formsView.IsTorchOn)
                     zxingSurface.Torch (true);
             }


### PR DESCRIPTION
…on has been granted on Android.

**This PR fixes the following issue**

When using a custom scan page, scanning is not active after camera permission has been granted on Android.

I had previously logged a bug to track the issue: https://github.com/Redth/ZXing.Net.Mobile/issues/582

**Steps to reproduce**

1. Run the Android sample project from a fresh installation on the device
2. Select 'Scan with custom overlay'
3. Allow permissions when requested
4. Attempt to scan a bar code

**Expected outcome**

The bar code should be scanned by the ZXingScannerView when the camera is shown after the permissions dialog has been dismissed.

**Actual outcome**

The bar code is not scanned after the permissions dialog has been dismissed.

This issue does not occur with the default overlay, or on the custom scan page on iOS. If the Android app is closed and re-opened after the permissions dialog has been dismissed, the issue does not occur.

**Fix**

It appears that in the normal flow, after permissions have been granted, IsScanning is set on OnElementPropertyChanged and this includes setting IsAnalysed = true. However due to the calling order when the permissions dialog is shown, this behaviour fails on Android with IsAnalysing being set immediately to false.

As a work around I attempted to explicitly set IsAnalysing = true but this had no effect.

The fix I'm proposing is to remove the following commented code:

```
 protected override async void OnElementChanged(ElementChangedEventArgs<ZXingScannerView> e)
        {
            ...

                ////if (!formsView.IsAnalyzing)
                ////    zxingSurface.PauseAnalysis ();

            ...            
        }
```

The fix resolves the issue and scanning works immediately on Android after granting camera permissions.