### PR TITLE
AVCaptureScanner: fixed incorrect return barcode type

### DIFF
--- a/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerView.cs
+++ b/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerView.cs
@@ -612,29 +612,36 @@ namespace ZXing.Mobile
 		}
 
 		BarcodeFormat ZXingBarcodeFormatFromAVCaptureBarcodeFormat(string avMetadataObjectType)
-		{	
-			if (avMetadataObjectType == AVMetadataObject.TypeAztecCode)
+		{
+			switch(avMetadataObjectType)
+			{
+			case "AztecCode":
 				return BarcodeFormat.AZTEC;
-			if (avMetadataObjectType == AVMetadataObject.TypeCode128Code)
+			case "Code128Code":
 				return BarcodeFormat.CODE_128;
-			if (avMetadataObjectType == AVMetadataObject.TypeCode39Code)
+			case "Code39Code":
 				return BarcodeFormat.CODE_39;
-			if (avMetadataObjectType == AVMetadataObject.TypeCode39Mod43Code)
+			case "Code39Mod43Code":
 				return BarcodeFormat.CODE_39;
-			if (avMetadataObjectType == AVMetadataObject.TypeCode93Code)
+			case "Code93Code":
 				return BarcodeFormat.CODE_93;
-			if (avMetadataObjectType == AVMetadataObject.TypeEAN13Code)
+			case "EAN13Code":
 				return BarcodeFormat.EAN_13;
-			if (avMetadataObjectType == AVMetadataObject.TypeEAN8Code)
+			case "EAN8Code":
 				return BarcodeFormat.EAN_8;
-			if (avMetadataObjectType == AVMetadataObject.TypePDF417Code)
+			case "PDF417Code":
 				return BarcodeFormat.PDF_417;
-			if (avMetadataObjectType == AVMetadataObject.TypeQRCode)
+			case "QRCode":
 				return BarcodeFormat.QR_CODE;
-			if (avMetadataObjectType == AVMetadataObject.TypeUPCECode)
+			case "UPCECode":
 				return BarcodeFormat.UPC_E;
-
-			return BarcodeFormat.QR_CODE;
+			case "DataMatrixCode":
+				return BarcodeFormat.DATA_MATRIX;
+			case "Interleaved2of5Code":
+				return BarcodeFormat.ITF;
+			default:
+				return BarcodeFormat.QR_CODE;
+			}		    
 		}
 
         #if __UNIFIED__


### PR DESCRIPTION
Reason for change: avMetadataObjectType gives strings in the format of `"AztecCode"` or `"Code128Code"`. However the comparison, e.g. `if (avMetadataObjectType == AVMetadataObject.TypeCode128Code)` is being done on:
1. A type not a string
2. Even after string conversion, mismatched data. e.g. AVMetadataObject.TypeAztecCode.ToString() === "org.iso.Aztec";

By all means feel free to correct my implementation, i'm not overly knowledgeable about the code base.

signed-off-by: Houman Brinjcargorabi <hbrinjcar@gmail.com>