### PR TITLE
AssumeGS1 scanning option support in mobile projects.

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
+++ b/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
@@ -191,6 +191,8 @@ namespace ZXing.Mobile.CameraAccess
                 _barcodeReader.TryInverted = _scanningOptions.TryInverted.Value;
             if (_scanningOptions.UseCode39ExtendedMode.HasValue)
                 _barcodeReader.Options.UseCode39ExtendedMode = _scanningOptions.UseCode39ExtendedMode.Value;
+            if (_scanningOptions.AssumeGS1.HasValue)
+                _barcodeReader.Options.AssumeGS1 = _scanningOptions.AssumeGS1.Value;
 
             if (_scanningOptions.PossibleFormats != null && _scanningOptions.PossibleFormats.Count > 0)
             {

--- a/Source/ZXing.Net.Mobile.Core/MobileBarcodeScanningOptions.cs
+++ b/Source/ZXing.Net.Mobile.Core/MobileBarcodeScanningOptions.cs
@@ -31,6 +31,7 @@ namespace ZXing.Mobile
 		public string CharacterSet { get;set; }
 		public bool? TryInverted { get;set; }
 		public bool? UseFrontCameraIfAvailable { get; set; }
+        public bool? AssumeGS1 { get; set; }
 
         public bool UseNativeScanning { get; set; }
 
@@ -59,6 +60,8 @@ namespace ZXing.Mobile
 				reader.Options.CharacterSet = this.CharacterSet;
 			if (this.TryInverted.HasValue)
 				reader.TryInverted = this.TryInverted.Value;
+            if (this.AssumeGS1.HasValue)
+                reader.Options.AssumeGS1 = this.AssumeGS1.Value;
 
 			if (this.PossibleFormats != null && this.PossibleFormats.Count > 0)
 			{

--- a/Source/ZXing.Net.Mobile.iOS/ZXingScannerView.cs
+++ b/Source/ZXing.Net.Mobile.iOS/ZXingScannerView.cs
@@ -327,6 +327,8 @@ namespace ZXing.Mobile
 				barcodeReader.Options.CharacterSet = ScanningOptions.CharacterSet;
 			if (ScanningOptions.TryInverted.HasValue)
 				barcodeReader.TryInverted = ScanningOptions.TryInverted.Value;
+            if (ScanningOptions.AssumeGS1.HasValue)
+                barcodeReader.Options.AssumeGS1 = ScanningOptions.AssumeGS1.Value;
 
 			if (ScanningOptions.PossibleFormats != null && ScanningOptions.PossibleFormats.Count > 0)
 			{


### PR DESCRIPTION
Exposes AssumeGS1 Option to mobile interfaces. This option allows GS1-128 barcode decomposition in Code 128 reader.