### PR TITLE
Android - Remove SurfaceHolderCallback on surface destroyed

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -46,6 +46,8 @@ namespace ZXing.Mobile
         public async void SurfaceDestroyed(ISurfaceHolder holder)
         {
             await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
+            
+            Holder.RemoveCallback(this);
 
             _cameraAnalyzer.ShutdownCamera();
         }


### PR DESCRIPTION
The callback are not removed before camera shutdown.
So the surface change event can be fired after or during camera shutdown.
The result is an ObjectDisposedException or an NullReferenceException in ApplyCameraSettings method.

Resolve #519, #554, #596, #602, #623, #627