### PR TITLE
[Android] Do not log scanned text

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
+++ b/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
@@ -154,7 +154,7 @@ namespace ZXing.Mobile.CameraAccess
 
             if (result != null)
             {
-                Android.Util.Log.Debug(MobileBarcodeScanner.TAG, "Barcode Found: " + result.Text);
+                Android.Util.Log.Debug(MobileBarcodeScanner.TAG, "Barcode Found");
 
                 _wasScanned = true;
                 BarcodeFound?.Invoke(this, result);


### PR DESCRIPTION
I removed the scanned text from the "Barcode found" log message.
The scanned text is not logged at the other platforms and i think it could be a security issue if the scanned barcode contains sensitive data (2 factor initialisation or similar).