### PR TITLE
[Android] Fix black screen after resume

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -201,5 +201,14 @@ namespace ZXing.Mobile
 			if (visibility == ViewStates.Visible)
 				Init();
 		}
+
+        public override async void OnWindowFocusChanged(bool hasWindowFocus)
+        {
+            base.OnWindowFocusChanged(hasWindowFocus);
+            if (!hasWindowFocus) return;
+            // SurfaceCreated/SurfaceChanged are not called on a resume
+            await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
+            _cameraAnalyzer.RefreshCamera();
+        }
     }
 }


### PR DESCRIPTION
`_cameraAnalyzer.SetupCamera()` is only called in `ZXingSurfaceView.SurfaceCreated`, but `SurfaceCreated` isn't called on a resume. Therefore, the camera gets shut down during sleep in `SurfaceDestroyed` and never set up again unless the user rotates their device. This was the easiest solution I could think of without refactoring a bunch of code. Seems to work well.

Fixes #655.

Kind of moot without #635.