### PR TITLE
resolve issue #569

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -43,6 +43,8 @@ namespace ZXing.Mobile
             await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
 
             _cameraAnalyzer.SetupCamera();
+
+            _surfaceCreated = true;
         }
 
         public async void SurfaceChanged(ISurfaceHolder holder, Format format, int wx, int hx)
@@ -140,6 +142,7 @@ namespace ZXing.Mobile
         public bool IsAnalyzing => _cameraAnalyzer.IsAnalyzing;
 
         private CameraAnalyzer _cameraAnalyzer;
+        private bool _surfaceCreated;
 
         public bool HasTorch => _cameraAnalyzer.Torch.IsSupported;
 
@@ -205,10 +208,14 @@ namespace ZXing.Mobile
         public override async void OnWindowFocusChanged(bool hasWindowFocus)
         {
             base.OnWindowFocusChanged(hasWindowFocus);
-            if (!hasWindowFocus) return;
-            // SurfaceCreated/SurfaceChanged are not called on a resume
-            await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
-            _cameraAnalyzer.RefreshCamera();
+            //only refresh the camera if the surface has already been created. Fixed #569
+            if (_surfaceCreated)
+            {
+                if (!hasWindowFocus) return;
+                // SurfaceCreated/SurfaceChanged are not called on a resume
+                await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
+                _cameraAnalyzer.RefreshCamera();
+            }
         }
     }
 }

--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -208,14 +208,14 @@ namespace ZXing.Mobile
         public override async void OnWindowFocusChanged(bool hasWindowFocus)
         {
             base.OnWindowFocusChanged(hasWindowFocus);
+            
+            if (!hasWindowFocus) return;
+            // SurfaceCreated/SurfaceChanged are not called on a resume
+            await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
+
             //only refresh the camera if the surface has already been created. Fixed #569
             if (_surfaceCreated)
-            {
-                if (!hasWindowFocus) return;
-                // SurfaceCreated/SurfaceChanged are not called on a resume
-                await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
                 _cameraAnalyzer.RefreshCamera();
-            }
         }
     }
 }


### PR DESCRIPTION
This change fixes issue #569 

The issue was that the navigationpage caused an OnWindowFocusChanged  to be fired, before SurfaceCreated was called. When a RefreshCamera method is called before the SetupCamera is called, SetupCamera is never called anymore, causing the camera event listeners not to be fired, and the whole component not working.