### PR TITLE
Add missing NuGet reference for Xamarin.Forms Android

### DIFF
--- a/ZXing.Net.Mobile.Forms.nuspec
+++ b/ZXing.Net.Mobile.Forms.nuspec
@@ -37,6 +37,7 @@
                 <dependency id="Xamarin.Forms" version="2.5.0.122203" />
             </group>
             <group targetFramework="MonoAndroid10">
+                <dependency id="ZXing.Net.Mobile" version="$version$" />
                 <dependency id="Xamarin.Android.Support.v4" version="25.4.0.2" />
                 <dependency id="FastAndroidCamera" version="2.0.0" />
             </group>


### PR DESCRIPTION
When the Forms nuspec was updated to support netstandard, the ZXing.Net.Mobile dependency was left out for Android. v2.4.1 forces us to reference the dependency manually.

Fixes #697 and #701.