### PR TITLE
BUGFIX - Forms Android SurfaceView when IsScanning is set to False th…

### DIFF
--- a/Samples/Forms/Core/CustomScanPage.cs
+++ b/Samples/Forms/Core/CustomScanPage.cs
@@ -31,7 +31,7 @@ namespace FormsSample
                     await DisplayAlert ("Scanned Barcode", result.Text, "OK");
 
                     // Navigate away
-                    await Navigation.PopAsync ();
+                    //await Navigation.PopAsync ();
                 });
 
             overlay = new ZXingDefaultOverlay
@@ -49,8 +49,42 @@ namespace FormsSample
                 VerticalOptions = LayoutOptions.FillAndExpand,
                 HorizontalOptions = LayoutOptions.FillAndExpand,
             };
+
+            var stopButton = new Button
+            {
+                WidthRequest = 100,
+                HeightRequest = 50,
+                HorizontalOptions = LayoutOptions.Start,
+                VerticalOptions = LayoutOptions.End,
+                Text = "disable",
+                Command = new Command(() => zxing.IsScanning=false)
+            };
+
+            var cancelButton = new Button
+            {
+                WidthRequest = 100,
+                HeightRequest = 50,
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.End,
+                Text = "cancel",
+                Command = new Command(async () => await Navigation.PopAsync())
+            };
+
+            var startButton = new Button
+            {
+                WidthRequest = 100,
+                HeightRequest = 50,
+                HorizontalOptions = LayoutOptions.End,
+                VerticalOptions = LayoutOptions.End,
+                Text = "enable",
+                Command = new Command(() => zxing.IsScanning = true)
+            };
+
             grid.Children.Add(zxing);
             grid.Children.Add(overlay);
+            grid.Children.Add(startButton);
+            grid.Children.Add(cancelButton);
+            grid.Children.Add(stopButton);
 
             // The root page of your application
             Content = grid;

--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -98,6 +98,7 @@ namespace ZXing.Mobile
 
         public void StartScanning(Action<Result> scanResultCallback, MobileBarcodeScanningOptions options = null)
         {
+            _cameraAnalyzer.SetupCamera();
             ScanningOptions = options ?? MobileBarcodeScanningOptions.Default;
 
             _cameraAnalyzer.BarcodeFound += (sender, result) =>


### PR DESCRIPTION
…e camera is disabled but never enabled when IsScanning is to True anytime after disable state

updated sample Forms to include buttons to turn off camera and then on as described in documentation by using IsScanning