### PR TITLE
fixed bindable IsScanning property to be settable multiple times (#496)

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
+++ b/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
@@ -14,6 +14,7 @@ namespace ZXing.Mobile.CameraAccess
         private DateTime _lastPreviewAnalysis = DateTime.UtcNow;
         private bool _wasScanned;
         IScannerSessionHost _scannerHost;
+        private bool _cameraSetup;
 
         public CameraAnalyzer(SurfaceView surfaceView, IScannerSessionHost scannerHost)
         {
@@ -41,15 +42,23 @@ namespace ZXing.Mobile.CameraAccess
 
         public void ShutdownCamera()
         {
-            IsAnalyzing = false;
-            _cameraEventListener.OnPreviewFrameReady -= HandleOnPreviewFrameReady;
-            _cameraController.ShutdownCamera();
+            if (_cameraSetup)
+            {
+                IsAnalyzing = false;
+                _cameraEventListener.OnPreviewFrameReady -= HandleOnPreviewFrameReady;
+                _cameraController.ShutdownCamera();
+                _cameraSetup = false;
+            }
         }
 
         public void SetupCamera()
         {
-            _cameraEventListener.OnPreviewFrameReady += HandleOnPreviewFrameReady;
-            _cameraController.SetupCamera();
+            if (!_cameraSetup)
+            {
+                _cameraEventListener.OnPreviewFrameReady += HandleOnPreviewFrameReady;
+                _cameraController.SetupCamera();
+                _cameraSetup = true;
+            }
         }
 
         public void AutoFocus()
@@ -64,7 +73,9 @@ namespace ZXing.Mobile.CameraAccess
 
         public void RefreshCamera()
         {
-            _cameraController.RefreshCamera();
+            //only refresh the camera if it is actually setup
+            if(_cameraSetup)
+                _cameraController.RefreshCamera();
         }
 
         private bool CanAnalyzeFrame

--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -40,11 +40,13 @@ namespace ZXing.Mobile
 
         public async void SurfaceCreated(ISurfaceHolder holder)
         {
-            await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
-
-            _cameraAnalyzer.SetupCamera();
-
-            _surfaceCreated = true;
+            //avoid duplicate setups, forcing the camera to be setup even when the camera was not scanning (this can happen when resuming the app)
+            if (!_surfaceCreated)
+            {
+                await ZXing.Net.Mobile.Android.PermissionsHandler.PermissionRequestTask;
+                _cameraAnalyzer.SetupCamera();
+                _surfaceCreated = true;
+            }
         }
 
         public async void SurfaceChanged(ISurfaceHolder holder, Format format, int wx, int hx)

--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -98,6 +98,9 @@ namespace ZXing.Mobile
 
         public void StartScanning(Action<Result> scanResultCallback, MobileBarcodeScanningOptions options = null)
         {
+            //make sure the camera is setup
+            _cameraAnalyzer.SetupCamera();
+
             ScanningOptions = options ?? MobileBarcodeScanningOptions.Default;
 
             _cameraAnalyzer.BarcodeFound += (sender, result) =>


### PR DESCRIPTION
This change fixes some open issues. One of them is #496 

The IsScanning property of the ScannerView Control is bindable, but once you switched it off an on, the scanner didn't work again, because the camera was no never re-initialized.

Furthermore, when scanning was disabled, and you left the page via a Navigation.PushAsync, the camera was setup again via a RefreshCamera call. However, this should not do anything if the camera is not initialized, because then the NonmarshalingPreviewCallback event listener was not attached again.

There is an existing pull request that has some of the changed of this pull request (#725) but this one fixes some more scenario's

edit:
I've added a commit to avoid the camera to be setup multiple times. In our app, we have a scannerview on our main page. When we disable scanning, and navigate to a different page, and open an external app via startactivityforresult, and then return to the app, the SurfaceCreated is called again. This causes the "SetupCamera" method to be called, and forces the SurfaceView into scanning mode, even when we disabled it before. The extra commit avoids this method from being called multiple times.