### PR TITLE
Fix for NullPointerException if the scanner view used inside a Xamari…

### DIFF
--- a/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
+++ b/Source/ZXing.Net.Mobile.Forms.Android/ZXingScannerViewRenderer.cs
@@ -12,16 +12,24 @@ using Android.Widget;
 using ZXing.Mobile;
 using System.Threading.Tasks;
 using System.Linq.Expressions;
+using Android.Content;
 
 [assembly:ExportRenderer(typeof(ZXingScannerView), typeof(ZXingScannerViewRenderer))]
 namespace ZXing.Net.Mobile.Forms.Android
 {
     [Preserve(AllMembers = true)]
     public class ZXingScannerViewRenderer : ViewRenderer<ZXingScannerView, ZXing.Mobile.ZXingSurfaceView>
-    {       
-        public ZXingScannerViewRenderer () : base ()
+    {
+        private Context appContext;
+        public ZXingScannerViewRenderer() { }
+        public ZXingScannerViewRenderer(IntPtr a, JniHandleOwnership b) { }
+        public ZXingScannerViewRenderer(Context context)
         {
+            appContext = context;
         }
+        //public ZXingScannerViewRenderer () : base ()
+        //{
+        //}
 
         public static void Init ()
         {
@@ -52,12 +60,12 @@ namespace ZXing.Net.Mobile.Forms.Android
                     }
                 };
 
-                var activity = Context as Activity;
+                var activity = appContext as Activity;
 
                 if (activity != null)                
                     await ZXing.Net.Mobile.Android.PermissionsHandler.RequestPermissionsAsync (activity);
                 
-                zxingSurface = new ZXingSurfaceView (Xamarin.Forms.Forms.Context as Activity, formsView.Options);
+                zxingSurface = new ZXingSurfaceView (appContext, formsView.Options);
                 zxingSurface.LayoutParameters = new LayoutParams (LayoutParams.MatchParent, LayoutParams.MatchParent);
 
                 base.SetNativeControl (zxingSurface);


### PR DESCRIPTION
I ran into 'Java.Lang.RuntimeException: Attempt to invoke virtual method 'android.content.res.Resources android.content.Context.getResources()' on a null object reference' exception when trying to open the Zxing scanner view from within the Xamarin Forms view. This started happening after the forms upgrade from 2.4 to 2.5. Xamarin.Forms.Forms.Context is obsolete as of version 2.5. The above fix resolved the crash as we are using the local context instead. Please review the PR and merge the changes.

The stack trace for the crash was as follows:
Attempt.getResources()
android.view.ViewConfiguration.get()ViewConfiguration.java:364
android.view.View.<init>()View.java:4022
android.view.View.<init>()View.java:4146
android.view.SurfaceView.<init>()SurfaceView.java:209
android.view.SurfaceView.<init>()SurfaceView.java:205
android.view.SurfaceView.<init>()SurfaceView.java:201
android.view.SurfaceView.<init>()SurfaceView.java:197
md55109d95aac470e32f9a4031a908f0227.ZXingSurfaceView.<init>()ZXingSurfaceView.java:29
mono.java.lang.RunnableImplementor.n_run(Native Method)
mono.java.lang.RunnableImplementor.run()RunnableImplementor.java:30
android.os.Handler.handleCallback()Handler.java:751
android.os.Handler.dispatchMessage()Handler.java:95
android.os.Looper.loop()Looper.java:154
android.app.ActivityThread.main()ActivityThread.java:6119
java.lang.reflect.Method.invoke(Native Method)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run()ZygoteInit.java:886
com.android.internal.os.ZygoteInit.main()ZygoteInit.java:776
caused.getResources()
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()<94d030a9db85465c8ba0646abb626fc8>:0
Java.Interop.JniEnvironment.InstanceMethods.CallNonvirtualVoidMethod(JniObjectReference instance, JniObjectReference type, JniMethodInfo method, JniArgumentValue* args)<cd9ed549df474efeb7f1ecb27a634c4d>:0
Java.Interop.JniPeerMembers.JniInstanceMethods.FinishCreateInstance(string constructorSignature, IJavaPeerable self, JniArgumentValue* parameters)<cd9ed549df474efeb7f1ecb27a634c4d>:0
Android.Views.SurfaceView.SurfaceView(Context context)<82c972649997496e8a181d0beeaab91e>:0
ZXing.Mobile.ZXingSurfaceView.ZXingSurfaceView(Activity activity, MobileBarcodeScanningOptions options)<04a6c4a6536f4e76a10998845fe4c337>:0
ZXing.Net.Mobile.Forms.Android.ZXingScannerViewRenderer.<OnElementChanged>d__5.MoveNext()<30849edafd8e4fbb9f24af588a9bebb0>:0
Android.App.SyncContext.<>c__DisplayClass2_0.<Post>b__0()<82c972649997496e8a181d0beeaab91e>:0
Java.Lang.Thread.RunnableImplementor.Run()<82c972649997496e8a181d0beeaab91e>:0
Java.Lang.IRunnableInvoker.n_Run(IntPtr jnienv, IntPtr native__this)<82c972649997496e8a181d0beeaab91e>:0
at (wrapper dynamic-method) System.Object:2319445d-51a5-46fb-a585-1d15839bca4d (intptr,intptr)
--- End of managed Java.Lang.RuntimeException stack trace ---
Attempt.getResources()
android.view.ViewConfiguration.get()ViewConfiguration.java:364
android.view.View.<init>()View.java:4022
android.view.View.<init>()View.java:4146
android.view.SurfaceView.<init>()SurfaceView.java:209
android.view.SurfaceView.<init>()SurfaceView.java:205
android.view.SurfaceView.<init>()SurfaceView.java:201
android.view.SurfaceView.<init>()SurfaceView.java:197
md55109d95aac470e32f9a4031a908f0227.ZXingSurfaceView.<init>()ZXingSurfaceView.java:29
mono.java.lang.RunnableImplementor.n_run(Native Method)
mono.java.lang.RunnableImplementor.run()RunnableImplementor.java:30
android.os.Handler.handleCallback()Handler.java:751
android.os.Handler.dispatchMessage()Handler.java:95
android.os.Looper.loop()Looper.java:154
android.app.ActivityThread.main()ActivityThread.java:6119
java.lang.reflect.Method.invoke(Native Method)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run()ZygoteInit.java:886
com.android.internal.os.ZygoteInit.main()ZygoteInit.java:776


