### PR TITLE
Scanner improvements - added the logic from original zxing android project to set the best camera settings

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
+++ b/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
@@ -1,3 +1,23 @@
+/*
+* Copyright 2018 ZXing/Redth - https://github.com/Redth/ZXing.Net.Mobile
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* 
+* Edited by VK, Apacheta Corp 11/14/2018.
+* http://www.apacheta.com/
+* 
+*/
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -12,14 +32,14 @@ namespace ZXing.Mobile.CameraAccess
     public class CameraAnalyzer
     {
         /// <summary>
-        ///START - Scanning Improvement, VK 10/2018
+        ///START - Scanning Improvement, VK 11/14/2018
         /// </summary>
         private const int MIN_FRAME_WIDTH = 240;
         private const int MIN_FRAME_HEIGHT = 240;
         private const int MAX_FRAME_WIDTH = 640; // = 5/8 * 1920
         private const int MAX_FRAME_HEIGHT = 480; // = 5/8 * 1080
         /// <summary>
-        /// END - Scanning Improvement, VK 10/2018
+        /// END - Scanning Improvement, VK 11/14/2018
         /// </summary>
         /// 
 
@@ -87,6 +107,7 @@ namespace ZXing.Mobile.CameraAccess
 
         /// <summary>
         ///Scanning Improvement, VK 10/2018
+        ///Removed this method for now.
         /// </summary>
         //public void LowLightMode(bool on)
         //{
@@ -185,7 +206,10 @@ namespace ZXing.Mobile.CameraAccess
             var start = PerformanceCounter.Start();
 
             /// <summary>
-            ///START - Scanning Improvement, VK 10/2018
+            ///START - Scanning Improvement, VK Apacheta Corp 11/14/2018
+            ///Added a new frame to get the center part of the captured image.
+            ///To create a FastJavaByteArray from the cropped captured frame and use it to decode the barcode.
+            ///To decrease the processing time drastically for higher resolution cameras.
             /// </summary>
             var frame_width = width * 3 / 5;
             var frame_height = height * 3 / 5;
@@ -201,7 +225,7 @@ namespace ZXing.Mobile.CameraAccess
                                                                             frame_height); // _area.Left, _area.Top, _area.Width, _area.Height);
 
             /// <summary>
-            ///END - Scanning Improvement, VK 10/2018
+            ///END - Scanning Improvement, VK Apacheta Corp 11/14/2018
             /// </summary>
             if (rotate)
                 fast = fast.rotateCounterClockwise();

--- a/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
+++ b/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
@@ -1,19 +1,39 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Android.Views;
 using ApxLabs.FastAndroidCamera;
+using Android.Graphics;
+using Android.Content;
+using Android.Util;
 
 namespace ZXing.Mobile.CameraAccess
 {
     public class CameraAnalyzer
     {
+        /// <summary>
+        ///START - Scanning Improvement, VK 10/2018
+        /// </summary>
+        private const int MIN_FRAME_WIDTH = 240;
+        private const int MIN_FRAME_HEIGHT = 240;
+        private const int MAX_FRAME_WIDTH = 640; // = 5/8 * 1920
+        private const int MAX_FRAME_HEIGHT = 480; // = 5/8 * 1080
+        /// <summary>
+        /// END - Scanning Improvement, VK 10/2018
+        /// </summary>
+        /// 
+
         private readonly CameraController _cameraController;
         private readonly CameraEventsListener _cameraEventListener;
+        private int _screenHeight = -1;
+        private int _screenWidth = -1;
         private Task _processingTask;
         private DateTime _lastPreviewAnalysis = DateTime.UtcNow;
         private bool _wasScanned;
         IScannerSessionHost _scannerHost;
+        private Rect framingRectInPreview;
+        private Rect framingRect;
+        private IWindowManager manager;
 
         public CameraAnalyzer(SurfaceView surfaceView, IScannerSessionHost scannerHost)
         {
@@ -21,6 +41,14 @@ namespace ZXing.Mobile.CameraAccess
             _cameraEventListener = new CameraEventsListener();
             _cameraController = new CameraController(surfaceView, _cameraEventListener, scannerHost);
             Torch = new Torch(_cameraController, surfaceView.Context);
+            try
+            {
+                manager = (surfaceView.Context as ZxingActivity)?.WindowManager;
+            }
+            catch(Exception ex)
+            {
+                Log.Debug(MobileBarcodeScanner.TAG, "Error occured while getting window manager : " + ex.ToString());
+            }
         }
 
         public event EventHandler<Result> BarcodeFound;
@@ -57,6 +85,14 @@ namespace ZXing.Mobile.CameraAccess
             _cameraController.AutoFocus();
         }
 
+        /// <summary>
+        ///Scanning Improvement, VK 10/2018
+        /// </summary>
+        //public void LowLightMode(bool on)
+        //{
+        //    _cameraController.LowLightMode(on);
+        //}
+
         public void AutoFocus(int x, int y)
         {
             _cameraController.AutoFocus(x, y);
@@ -65,6 +101,14 @@ namespace ZXing.Mobile.CameraAccess
         public void RefreshCamera()
         {
             _cameraController.RefreshCamera();
+        }
+
+        private bool Valid_ScreenResolution
+        {
+            get
+            {
+                return _screenHeight > 0 && _screenWidth > 0;
+            }
         }
 
         private bool CanAnalyzeFrame
@@ -103,14 +147,15 @@ namespace ZXing.Mobile.CameraAccess
 			{
 				try
 				{
-					DecodeFrame(fastArray);
+                    Log.Debug(MobileBarcodeScanner.TAG, "Preview Analyzing.");
+                    DecodeFrame(fastArray);
 				} catch (Exception ex) {
 					Console.WriteLine(ex);
 				}
 			}).ContinueWith(task =>
             {
                 if (task.IsFaulted)
-                    Android.Util.Log.Debug(MobileBarcodeScanner.TAG, "DecodeFrame exception occurs");
+                    Log.Debug(MobileBarcodeScanner.TAG, "DecodeFrame exception occurs");
             }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
@@ -139,7 +184,25 @@ namespace ZXing.Mobile.CameraAccess
             ZXing.Result result = null;
             var start = PerformanceCounter.Start();
 
-            LuminanceSource fast = new FastJavaByteArrayYUVLuminanceSource(fastArray, width, height, 0, 0, width, height); // _area.Left, _area.Top, _area.Width, _area.Height);
+            /// <summary>
+            ///START - Scanning Improvement, VK 10/2018
+            /// </summary>
+            var frame_width = width * 3 / 5;
+            var frame_height = height * 3 / 5;
+            var frame_left = width * 1 / 5;
+            var frame_top = height * 1 / 5;
+           
+            LuminanceSource fast = new FastJavaByteArrayYUVLuminanceSource(fastArray, width, height,
+                                                                            //framingRectPreview?.Width() ?? width,
+                                                                           // framingRectPreview?.Height() ?? height,
+                                                                            frame_left,
+                                                                            frame_top,
+                                                                            frame_width,
+                                                                            frame_height); // _area.Left, _area.Top, _area.Width, _area.Height);
+
+            /// <summary>
+            ///END - Scanning Improvement, VK 10/2018
+            /// </summary>
             if (rotate)
                 fast = fast.rotateCounterClockwise();
 
@@ -149,17 +212,139 @@ namespace ZXing.Mobile.CameraAccess
             fastArray = null;
 
             PerformanceCounter.Stop(start,
-                "Decode Time: {0} ms (width: " + width + ", height: " + height + ", degrees: " + cDegrees + ", rotate: " +
-                rotate + ")");
+                $"width: {width}, height: {height}, frame_top :{frame_top}, frame_left: {frame_left}, frame_width: {frame_width}, frame_height: {frame_height}, degrees: {cDegrees}, rotate: {rotate}; " + "Decode Time: {0} ms");
 
             if (result != null)
             {
-                Android.Util.Log.Debug(MobileBarcodeScanner.TAG, "Barcode Found");
+                Log.Debug(MobileBarcodeScanner.TAG, "Barcode Found");
 
                 _wasScanned = true;
                 BarcodeFound?.Invoke(this, result);
                 return;
             }
+        }
+
+
+        /// <summary>
+        ///Scanning Improvement, VK 10/2018
+        /// </summary>
+        private Rect GetFramingRectInPreview()
+        {
+            if (framingRectInPreview == null)
+            {
+                //if (!Valid_ScreenResolution)
+                //    GetScreenResolution();
+                var cameraParameters = _cameraController?.Camera?.GetParameters();
+                var width = cameraParameters.PreviewSize.Width;
+                var height = cameraParameters.PreviewSize.Height;
+                if (cameraParameters == null)//|| !Valid_ScreenResolution)
+                {
+                    // Called early, before init even finished
+                    return null;
+                }
+
+                var framingRect = GetFramingRect(width, height);
+                if (framingRect == null)
+                {
+                    return null;
+                }
+
+                var rect = new Rect(framingRect);
+                //var cameraParameters = _cameraController?.Camera?.GetParameters();
+                //var width = cameraParameters.PreviewSize.Width;
+                //var height = cameraParameters.PreviewSize.Height;
+            
+
+                //rect.Left = rect.Left * width / _screenWidth;
+                //rect.Right = rect.Right * width / _screenHeight;
+                //rect.Top = rect.Top * height / _screenWidth;
+                //rect.Bottom = rect.Bottom * height / _screenHeight;
+                framingRectInPreview = rect;
+                Log.Debug(MobileBarcodeScanner.TAG, $"preview resolution: w={width}; h={height}; _screenWidth ={_screenWidth}; _screenHeight={_screenHeight}; framingRect={framingRect?.ToString()}");
+            }
+
+            Log.Debug(MobileBarcodeScanner.TAG, $"Calculated preview framing rect: {framingRectInPreview?.FlattenToString()}");
+            return framingRectInPreview;
+        }
+
+        /// <summary>
+        ///Scanning Improvement, VK 10/2018
+        /// </summary>
+        public Rect GetFramingRect(int _width, int _height)
+        {
+            if (framingRect == null)
+            {
+                if (_cameraController == null)
+                {
+                    return null;
+                }
+
+                if (!(_width > 0 && _height > 0))//Valid_ScreenResolution)
+                {
+                    // Called early, before init even finished
+                    return null;
+                }
+
+                int width = findDesiredDimensionInRange(_width, MIN_FRAME_WIDTH, MAX_FRAME_WIDTH);
+                int height = findDesiredDimensionInRange(_height, MIN_FRAME_HEIGHT, MAX_FRAME_HEIGHT);
+
+                int leftOffset = (_width - width) / 2;
+                int topOffset = (_height - height) / 2;
+                framingRect = new Rect(leftOffset, topOffset, width, height);
+                Log.Debug(MobileBarcodeScanner.TAG, $"Calculated framing rect: {framingRect?.FlattenToString()}; screenWidth: {_screenWidth}; screenHeight: {_screenHeight}");
+            }
+
+            return framingRect;
+        }
+
+        /// <summary>
+        ///Scanning Improvement, VK 10/2018
+        /// </summary>
+        private void GetScreenResolution()
+        {
+            var screenResolution = new DisplayMetrics();
+            try
+            {
+                if(manager == null)
+                {
+                    Log.Debug(MobileBarcodeScanner.TAG, $"Window manager is null.");
+                }
+
+                Display display = manager?.DefaultDisplay;
+                if (display == null)
+                {
+                    Log.Debug(MobileBarcodeScanner.TAG, $"Default display is null.");
+                }
+                else
+                {
+
+                    display?.GetMetrics(screenResolution);
+                    _screenWidth = screenResolution.WidthPixels;
+                    _screenHeight = screenResolution.HeightPixels;
+                }
+                Log.Debug(MobileBarcodeScanner.TAG, $"Screen Display Rect-  Width = {_screenWidth}; Height = {_screenHeight} ");
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(MobileBarcodeScanner.TAG, "Error occured while getting screen resolution : " + ex.ToString());
+            }
+        }
+
+        /// <summary>
+        ///Scanning Improvement, VK 10/2018
+        /// </summary>
+        private int findDesiredDimensionInRange(int resolution, int hardMin, int hardMax)
+        {
+            int dim = 5 * resolution / 8; // Target 5/8 of each dimension
+            if (dim < hardMin)
+            {
+                return hardMin;
+            }
+            if (dim > hardMax)
+            {
+                return hardMax;
+            }
+            return dim;
         }
     }
 }

--- a/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraController.cs
+++ b/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraController.cs
@@ -1,3 +1,23 @@
+/*
+* Copyright 2018 ZXing/Redth - https://github.com/Redth/ZXing.Net.Mobile
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* 
+* Edited by VK, Apacheta Corp 11/14/2018.
+* http://www.apacheta.com/
+* 
+*/
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -291,7 +311,9 @@ namespace ZXing.Mobile.CameraAccess
                             $" Setting Selected fps to Min:{selectedFps[0]}, Max {selectedFps[1]}");
 
                 /// <summary>
-                ///Scanning Improvement, VK 10/2018
+                ///Scanning Improvement, Apacheta corporation 11/14/2018
+                ///Changed the fps to use low and high. instead of low value and low value ie., selectedFps[0].
+                ///Old code ::  parameters.SetPreviewFpsRange(selectedFps[0], selectedFps[0]);
                 /// </summary>
                 parameters.SetPreviewFpsRange(selectedFps[0], selectedFps[1]);
             }
@@ -300,6 +322,7 @@ namespace ZXing.Mobile.CameraAccess
                 SetBestExposure(parameters, parameters.FlashMode != Camera.Parameters.FlashModeOn);
 
             /*
+             * Edited by VK - Apacheta corporation 11/14/2018
              * Improvements based on zxing android library
              * - Setting default auto focus areas instead of single focus point
              * - Setting Barcode scene mode if available for the device
@@ -368,7 +391,8 @@ namespace ZXing.Mobile.CameraAccess
         }
 
         /// <summary>
-        ///Scanning Improvement, VK 10/2018
+        ///Scanning Improvement, VK, Apacheta Corp 11/14/2018.
+        ///This method sets the best expsure setting for the device.
         /// </summary>
         private void SetBestExposure(Camera.Parameters parameters, bool lowLight)
         {
@@ -400,7 +424,8 @@ namespace ZXing.Mobile.CameraAccess
         }
 
         /// <summary>
-        ///Scanning Improvement, VK 10/2018
+        ///Scanning Improvement, VK Apacheta Corp 11/14/2018.
+        ///This method sets the focus area setting for the device. center rectangle
         /// </summary>
         private void SetDefaultFocusArea(Camera.Parameters parameters)
         {
@@ -416,8 +441,10 @@ namespace ZXing.Mobile.CameraAccess
             }
         }
 
+
         /// <summary>
-        ///Scanning Improvement, VK 10/2018
+        ///Scanning Improvement, VK Apacheta Corp 11/14/2018.
+        ///This method sets the meter setting for the device. center rectangle
         /// </summary>
         private void SetMetering(Camera.Parameters parameters)
         {
@@ -434,7 +461,8 @@ namespace ZXing.Mobile.CameraAccess
         }
 
         /// <summary>
-        ///Scanning Improvement, VK 10/2018
+        ///Scanning Improvement, VK Apacheta Corp 11/14/2018.
+        ///This method builds the middle are i.e., center rectangle for the device
         /// </summary>
         private List<Camera.Area> BuildMiddleArea(int areaPer1000)
         {
@@ -444,8 +472,11 @@ namespace ZXing.Mobile.CameraAccess
                 };
         }
 
+
         /// <summary>
-        ///Scanning Improvement, VK 10/2018
+        ///Scanning Improvement, VK Apacheta Corp 11/14/2018.
+        ///This method sets the Video stabilization setting for the device. 
+        ///This method is not used in the code for now. 
         /// </summary>
         private void SetVideoStabilization(Camera.Parameters parameters)
         {
@@ -468,7 +499,8 @@ namespace ZXing.Mobile.CameraAccess
         }
 
         /// <summary>
-        ///Scanning Improvement, VK 10/2018
+        ///Scanning Improvement, VK Apacheta Corp 11/14/2018.
+        ///This method sets the scene to barcode for the device. If the device supports scenes.
         /// </summary>
         private void SetBarcodeSceneMode(Camera.Parameters parameters)
         {


### PR DESCRIPTION
I added improvements for scanner for android library
1) Set the default focus area
2) Set the best exposure and metering area to the middle of the device (a rectangular area in the middle)
3) use that area to crop the actual image taken from device to decode the barcode image (lessen the processing time, this improvement is more than 1/4 compared to the original processing time.)
4) This code is based on the original zxing android project changes.