### PR TITLE
Core: use IEnumberable<Foo> instead of List<Foo>

### DIFF
--- a/Source/ZXing.Net.Mobile.Core/MobileBarcodeScanningOptions.cs
+++ b/Source/ZXing.Net.Mobile.Core/MobileBarcodeScanningOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using ZXing;
@@ -23,7 +24,7 @@ namespace ZXing.Mobile
 		}
 
 		public CameraResolutionSelectorDelegate CameraResolutionSelector { get;set; }
-		public List<BarcodeFormat> PossibleFormats { get;set; }
+		public IEnumerable<BarcodeFormat> PossibleFormats { get;set; }
 		public bool? TryHarder { get;set; } 
 		public bool? PureBarcode { get;set; }
 		public bool? AutoRotate { get;set; }
@@ -66,7 +67,7 @@ namespace ZXing.Mobile
             if (this.AssumeGS1.HasValue)
                 reader.Options.AssumeGS1 = this.AssumeGS1.Value;
 
-			if (this.PossibleFormats != null && this.PossibleFormats.Count > 0)
+			if (this.PossibleFormats != null && this.PossibleFormats.Any())
 			{
 				reader.Options.PossibleFormats = new List<BarcodeFormat>();
 
@@ -88,7 +89,7 @@ namespace ZXing.Mobile
 			if (this.PureBarcode.HasValue && this.PureBarcode.Value)
 				hints.Add(DecodeHintType.PURE_BARCODE, this.PureBarcode.Value);
 
-			if (this.PossibleFormats != null && this.PossibleFormats.Count > 0)
+			if (this.PossibleFormats != null && this.PossibleFormats.Any())
 			hints.Add(DecodeHintType.POSSIBLE_FORMATS, this.PossibleFormats);
 
 			reader.Hints = hints;

--- a/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerView.cs
+++ b/Source/ZXing.Net.Mobile.iOS/AVCaptureScannerView.cs
@@ -236,7 +236,7 @@ namespace ZXing.Mobile
 			session.AddOutput (metadataOutput);
 
 			//Setup barcode formats
-			if (ScanningOptions.PossibleFormats != null && ScanningOptions.PossibleFormats.Count > 0)
+			if (ScanningOptions.PossibleFormats != null && ScanningOptions.PossibleFormats.Any())
 			{
                 #if __UNIFIED__
                 var formats = AVMetadataObjectType.None;


### PR DESCRIPTION
Thanks to this, the API is easier to consume, especially
for languages that don't use mutable collections in an
idiomatic way (e.g. F#).