### PR TITLE
Fixed the problem with barcode rendering upside down on macOS

### DIFF
--- a/Samples/macOS/Sample.macOS/Info.plist
+++ b/Samples/macOS/Sample.macOS/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.14</string>
+	<string>10.13</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/Source/ZXing.Net.Mobile.macOS/BitmapRenderer.cs
+++ b/Source/ZXing.Net.Mobile.macOS/BitmapRenderer.cs
@@ -1,18 +1,13 @@
 ﻿using System;
 using ZXing.Rendering;
-
-using Foundation;
-using CoreFoundation;
 using CoreGraphics;
 using AppKit;
-
 using ZXing.Common;
 
 namespace ZXing.Mobile
 {
     public class BitmapRenderer : IBarcodeRenderer<NSImage>
     {
-
         public NSImage Render(BitMatrix matrix, BarcodeFormat format, string content)
         {
             return Render(matrix, format, content, new EncodingOptions());
@@ -25,11 +20,12 @@ namespace ZXing.Mobile
             var black = new CGColor(0f, 0f, 0f);
             var white = new CGColor(1.0f, 1.0f, 1.0f);
 
-            for (int x = 0; x < matrix.Width; x++)
+            for (var x = 0; x < matrix.Width; x++)
             {
-                for (int y = 0; y < matrix.Height; y++)
+                for (var y = 0; y < matrix.Height; y++)
                 {
-                    context.SetFillColor(matrix[x, y] ? black : white);
+                    var (cgX, cgY) = TransformToCoreGraphicsCoords(x, y, matrix);
+                    context.SetFillColor(matrix[cgX, cgY] ? black : white);
                     context.FillRect(new CGRect(x, y, 1, 1));
                 }
             }
@@ -38,6 +34,11 @@ namespace ZXing.Mobile
             context.Dispose();
 
             return img;
+        }
+
+        private static (int cgX, int cgY) TransformToCoreGraphicsCoords(int x, int y, BitMatrix matrix)
+        {
+            return (x, Math.Abs(y - matrix.Height + 1));
         }
     }
 }


### PR DESCRIPTION
I noticed that barcodes are rendered upside down on macOS.

![screen shot 2019-02-01 at 16 53 56](https://user-images.githubusercontent.com/5658947/52134242-6de68900-2643-11e9-952e-019deabcb23d.png)

It looks like the author of the macOS solution didn't notice that Core Graphics has a different coordinate system than UIKit https://developer.apple.com/library/archive/documentation/General/Conceptual/Devpedia-CocoaApp/CoordinateSystem.html
