### PR TITLE
Issues#794: Do not throw UnauthorizedAccessException when denying camera access.

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/PermissionsHandler.cs
+++ b/Source/ZXing.Net.Mobile.Android/PermissionsHandler.cs
@@ -142,7 +142,7 @@ namespace ZXing.Net.Mobile.Android
 
             global::Android.Util.Log.Debug(MobileBarcodeScanner.TAG, "Checking " + permission + "...");
 
-            if (!IsPermissionInManifest(context, permission) || !IsPermissionGranted(context, permission))
+            if (!IsPermissionInManifest(context, permission))
             {
                 result = false;
 


### PR DESCRIPTION
Fixes #794 

I don't know what should happen when `IsPermissionGranted(context, permission)` returns `false`. But imho it should not say that the Permission could not be found in the `AndroidManifest.xml` and the App should not crash.