### PR TITLE
FragmentActivity - Pause and Resume causes scanResult callbacks to pile up

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
+++ b/Source/ZXing.Net.Mobile.Android/CameraAccess/CameraAnalyzer.cs
@@ -23,7 +23,7 @@ namespace ZXing.Mobile.CameraAccess
             Torch = new Torch(_cameraController, surfaceView.Context);
         }
 
-        public event EventHandler<Result> BarcodeFound;
+        public Action<Result> BarcodeFound;
 
         public Torch Torch { get; }
 
@@ -157,7 +157,7 @@ namespace ZXing.Mobile.CameraAccess
                 Android.Util.Log.Debug(MobileBarcodeScanner.TAG, "Barcode Found");
 
                 _wasScanned = true;
-                BarcodeFound?.Invoke(this, result);
+                BarcodeFound?.Invoke(result);
                 return;
             }
         }

--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -100,7 +100,7 @@ namespace ZXing.Mobile
         {
             ScanningOptions = options ?? MobileBarcodeScanningOptions.Default;
 
-            _cameraAnalyzer.BarcodeFound += (sender, result) =>
+            _cameraAnalyzer.BarcodeFound = (result) =>
             {
                 scanResultCallback?.Invoke(result);
             };


### PR DESCRIPTION
A callback action is passed down until suddenly an event is used. Due to StartScanning being triggered from the OnResume, triggering OnResume multiple times will cause multiple scanResultCallbacks to trigger.