### PR TITLE
Reset AVCaptureDevice configurations on camera shutdown in iOS

### DIFF
--- a/Samples/Sample.iOS/AppDelegate.cs
+++ b/Samples/Sample.iOS/AppDelegate.cs
@@ -2,13 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-#if __UNIFIED__
 using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace Sample.iOS
 {
@@ -32,7 +27,7 @@ namespace Sample.iOS
 		//
 		public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 		{
-			Xamarin.Calabash.Start();
+			//Xamarin.Calabash.Start();
 
 			// create a new window instance based on the screen size
 			window = new UIWindow(UIScreen.MainScreen.Bounds);

--- a/ZXing.Net.Mobile/iOS/UIImageBarcodeReader.ios.cs
+++ b/ZXing.Net.Mobile/iOS/UIImageBarcodeReader.ios.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UIKit;
+using ZXing.Mobile;
+
+namespace ZXing.Mobile
+{
+	public class UIImageBarcodeReader : BarcodeReader<UIImage>, IBarcodeReader
+	{
+		static readonly Func<UIImage, LuminanceSource> defaultCreateLuminanceSource =
+		   (img) => new RGBLuminanceSourceiOS(img);
+
+		public UIImageBarcodeReader()
+		   : this(null, defaultCreateLuminanceSource, null)
+		{
+		}
+
+		public UIImageBarcodeReader(Reader reader,
+		   Func<UIImage, LuminanceSource> createLuminanceSource,
+		   Func<LuminanceSource, Binarizer> createBinarizer
+		)
+		   : base(reader, createLuminanceSource ?? defaultCreateLuminanceSource, createBinarizer)
+		{
+		}
+
+		public UIImageBarcodeReader(Reader reader,
+		   Func<UIImage, LuminanceSource> createLuminanceSource,
+		   Func<LuminanceSource, Binarizer> createBinarizer,
+		   Func<byte[], int, int, RGBLuminanceSource.BitmapFormat, LuminanceSource> createRGBLuminanceSource
+		)
+		   : base(reader, createLuminanceSource ?? defaultCreateLuminanceSource, createBinarizer, createRGBLuminanceSource)
+		{
+		}
+	}
+}


### PR DESCRIPTION
Apparently if you change some AVCaptureDevice settings on iOS and don't change them back, they are persisted to subsequent uses of the device within the same app.

This should help with #863 