### PR TITLE
Fix Refresh Rate (FPS) issues on certain android devices

### DIFF
--- a/ZXing.Net.Mobile/Android/CameraAccess/CameraController.android.cs
+++ b/ZXing.Net.Mobile/Android/CameraAccess/CameraController.android.cs
@@ -242,12 +242,11 @@ namespace ZXing.Mobile.CameraAccess
 			var selectedFps = parameters.SupportedPreviewFpsRange.FirstOrDefault();
 			if (selectedFps != null)
 			{
-				// This will make sure we select a range with the lowest minimum FPS
-				// and maximum FPS which still has the lowest minimum
-				// This should help maximize performance / support for hardware
+				// This will make sure we select a range with the highest maximum fps
+				// which still has the lowest minimum fps (Widest Range)
 				foreach (var fpsRange in parameters.SupportedPreviewFpsRange)
 				{
-					if (fpsRange[0] <= selectedFps[0] && fpsRange[1] > selectedFps[1])
+					if (fpsRange[1] > selectedFps[1] || fpsRange[1] == selectedFps[1] && fpsRange[0] < selectedFps[0])
 						selectedFps = fpsRange;
 				}
 				parameters.SetPreviewFpsRange(selectedFps[0], selectedFps[1]);


### PR DESCRIPTION
Update refresh rate selection to choose the highest FPS with the widest range in order to improve compatibility across devices and avoid selecting obscenely low fps values.

The purpose of this is to help mitigate issues like #492 

Essentially on some android devices like some variants of the samsung galaxy J7 the camera displays a possible refresh value of 7000-7000 which under the current algorithm will always be selected.  However, for the purposes of scanning that makes the refresh rate far too low and the device lags and struggled to scan the image.  This change will adjust the algorithm to keep selecting similar values as the current one to maintain high compatibility but avoid the extremely low refresh rate options.

Samsung J7 FPS Ranges:

7000-7000
15000-15000
24000-24000
8000-30000
10000-30000
15000-30000
30000-30000

Current Selected Refresh Range (before this change):
7000-7000

New Selected Refresh Range (with this change):
8000-30000