### PR TITLE
Reduce allocations per frame decode on android.

### DIFF
--- a/ZXing.Net.Mobile/Android/CameraAccess/CameraAnalyzer.android.cs
+++ b/ZXing.Net.Mobile/Android/CameraAccess/CameraAnalyzer.android.cs
@@ -1,19 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Android.Views;
 using ApxLabs.FastAndroidCamera;
 
 namespace ZXing.Mobile.CameraAccess
 {
-	public class CameraAnalyzer
+    public class CameraAnalyzer
 	{
 		readonly CameraController cameraController;
 		readonly CameraEventsListener cameraEventListener;
 		Task processingTask;
 		DateTime lastPreviewAnalysis = DateTime.UtcNow;
 		bool wasScanned;
-		IScannerSessionHost scannerHost;
+        readonly IScannerSessionHost scannerHost;
+		BarcodeReader barcodeReader;
 
 		public CameraAnalyzer(SurfaceView surfaceView, IScannerSessionHost scannerHost)
 		{
@@ -46,6 +46,7 @@ namespace ZXing.Mobile.CameraAccess
 		{
 			cameraEventListener.OnPreviewFrameReady += HandleOnPreviewFrameReady;
 			cameraController.SetupCamera();
+			barcodeReader = scannerHost.ScanningOptions.BuildBarcodeReader();
 		}
 
 		public void AutoFocus()
@@ -108,11 +109,9 @@ namespace ZXing.Mobile.CameraAccess
 
 		void DecodeFrame(FastJavaByteArray fastArray)
 		{
-			var cameraParameters = cameraController.Camera.GetParameters();
-			var width = cameraParameters.PreviewSize.Width;
-			var height = cameraParameters.PreviewSize.Height;
-
-			var barcodeReader = scannerHost.ScanningOptions.BuildBarcodeReader();
+			var cameraPreviewSize = cameraController.Camera.GetParameters().PreviewSize;
+			var width = cameraPreviewSize.Width;
+			var height = cameraPreviewSize.Height;
 
 			var rotate = false;
 			var newWidth = width;
@@ -128,14 +127,13 @@ namespace ZXing.Mobile.CameraAccess
 				newHeight = width;
 			}
 
-			ZXing.Result result = null;
 			var start = PerformanceCounter.Start();
 
 			LuminanceSource fast = new FastJavaByteArrayYUVLuminanceSource(fastArray, width, height, 0, 0, width, height); // _area.Left, _area.Top, _area.Width, _area.Height);
 			if (rotate)
 				fast = fast.rotateCounterClockwise();
 
-			result = barcodeReader.Decode(fast);
+            var result = barcodeReader.Decode(fast);
 
 			fastArray.Dispose();
 			fastArray = null;

--- a/ZXing.Net.Mobile/Android/CameraAccess/CameraAnalyzer.android.cs
+++ b/ZXing.Net.Mobile/Android/CameraAccess/CameraAnalyzer.android.cs
@@ -109,9 +109,9 @@ namespace ZXing.Mobile.CameraAccess
 
 		void DecodeFrame(FastJavaByteArray fastArray)
 		{
-			var cameraPreviewSize = cameraController.Camera.GetParameters().PreviewSize;
-			var width = cameraPreviewSize.Width;
-			var height = cameraPreviewSize.Height;
+			var resolution = cameraController.CameraResolution;
+			var width = resolution.Width;
+			var height = resolution.Height;
 
 			var rotate = false;
 			var newWidth = width;

--- a/ZXing.Net.Mobile/Android/CameraAccess/CameraController.android.cs
+++ b/ZXing.Net.Mobile/Android/CameraAccess/CameraController.android.cs
@@ -32,6 +32,8 @@ namespace ZXing.Mobile.CameraAccess
 
 		public Camera Camera { get; private set; }
 
+		public CameraResolution CameraResolution { get; private set; }
+
 		public int LastCameraDisplayOrientationDegree { get; private set; }
 
 		public void RefreshCamera()
@@ -301,6 +303,8 @@ namespace ZXing.Mobile.CameraAccess
 			{
 				Android.Util.Log.Debug(MobileBarcodeScanner.TAG,
 					"Selected Resolution: " + resolution.Width + "x" + resolution.Height);
+
+				CameraResolution = resolution;
 				parameters.SetPreviewSize(resolution.Width, resolution.Height);
 			}
 


### PR DESCRIPTION
While decoding each frame on android devices - the scanner options allocate a barcode reader based on options that are passed to the scanner.  However, since those options are passed when the scan begins - there is no reason to re-create this object each frame as it slows down the decode slightly and  results in a decent amount of excess allocations.

This change simply moves the allocation of the reader to happen when the camera is setup instead of when each frame is decoded.