### PR TITLE
[Android] Avoid crash if OnPreviewFrame data argument is null or IntPtr.Zero

### DIFF
--- a/ZXing.Net.Mobile/Android/CameraAccess/CameraEventsListener.android.cs
+++ b/ZXing.Net.Mobile/Android/CameraAccess/CameraEventsListener.android.cs
@@ -10,11 +10,14 @@ namespace ZXing.Mobile.CameraAccess
 
 		public void OnPreviewFrame(IntPtr data, Camera camera)
 		{
-			using (var fastArray = new FastJavaByteArray(data))
+			if (data != null && data != IntPtr.Zero)
 			{
-				OnPreviewFrameReady?.Invoke(this, fastArray);
+				using (var fastArray = new FastJavaByteArray(data))
+				{
+					OnPreviewFrameReady?.Invoke(this, fastArray);
 
-				camera.AddCallbackBuffer(fastArray);
+					camera.AddCallbackBuffer(fastArray);
+				}
 			}
 		}
 


### PR DESCRIPTION
Avoid crash if OnPreviewFrame data argument is null or IntPtr.Zero

Got crash on LG G7 thinQ:

**System.ArgumentNullException: Value cannot be null. Parameter name: handle**
`
ApxLabs.FastAndroidCamera.FastJavaByteArray..ctor (System.IntPtr handle, System.Boolean readOnly) [0x00016] in <9f646a7d069141bb922b3d2db31483e1>:0
CameraEventsListener.OnPreviewFrame (System.IntPtr data, Android.Hardware.Camera camera)
INonMarshalingPreviewCallbackInvoker.n_OnPreviewFrame_arrayBLandroid_hardware_Camera_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_data, System.IntPtr native_camera)
(wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.128(intptr,intptr,intptr,intptr)
`