### PR TITLE
Fix scanning not running when calling StartScanning

### DIFF
--- a/ZXing.Net.Mobile/Android/ZXingScannerFragment.android.cs
+++ b/ZXing.Net.Mobile/Android/ZXingScannerFragment.android.cs
@@ -50,6 +50,12 @@ namespace ZXing.Mobile
 				Console.WriteLine("Create Surface View Failed: " + ex);
 			}
 
+			// Someone tried to call StartScanning before we were ready. Call it again.
+			if (scanCallback != null)
+			{
+				StartScanning(scanCallback, ScanningOptions);
+			}
+
 			Android.Util.Log.Debug(MobileBarcodeScanner.TAG, "ZXingScannerFragment->OnResume exit");
 
 			return frame;


### PR DESCRIPTION
If someone calls `StartScanning` before the `OnCreateView` lifecycle methodis finished doing its thing setting up the Surface etc. Then the callback they pass in StartScanning, never gets triggered.

This fixes this issue, by assuming that in case of someone calling `StartScanning` before `OnCreateView`, then `scanCallback` is set. In such case just call `StartScanning` again to acutally start scanning and the `Scan()` method is invoked and everyone is happy.

I don't believe this is a breaking change. Since `StartScanning` will only get triggered in `OnCreateView` if the dev already tried calling it prematurely.

Fixes #934 