### PR TITLE
Fixing ios front camera crash issue.

### DIFF
--- a/ZXing.Net.Mobile/iOS/ZXingScannerView.ios.cs
+++ b/ZXing.Net.Mobile/iOS/ZXingScannerView.ios.cs
@@ -562,12 +562,14 @@ namespace ZXing.Mobile
 			// Revert camera settings to original
 			if (captureDevice != null && captureDevice.LockForConfiguration(out var err))
 			{
-				captureDevice.FocusMode = captureDeviceOriginalConfig.FocusMode;
 				captureDevice.ExposureMode = captureDeviceOriginalConfig.ExposureMode;
 				captureDevice.WhiteBalanceMode = captureDeviceOriginalConfig.WhiteBalanceMode;
 
 				if (UIDevice.CurrentDevice.CheckSystemVersion(7, 0) && captureDevice.AutoFocusRangeRestrictionSupported)
 					captureDevice.AutoFocusRangeRestriction = captureDeviceOriginalConfig.AutoFocusRangeRestriction;
+
+				if (captureDevice.IsFocusModeSupported(captureDeviceOriginalConfig.FocusMode))
+					captureDevice.FocusMode = captureDeviceOriginalConfig.FocusMode;
 
 				if (captureDevice.FocusPointOfInterestSupported)
 					captureDevice.FocusPointOfInterest = captureDeviceOriginalConfig.FocusPointOfInterest;


### PR DESCRIPTION
Found the crash to be related to trying to set an unsupported focus mode on the camera. To fix it I've added a check using `IsFocusModeSupport()` to make sure it is ok to set the focus mode back to the original.

https://github.com/Redth/ZXing.Net.Mobile/issues/978