### PR TITLE
Bug fix: Torch wasn't working

### DIFF
--- a/ZXing.Net.Mobile/iOS/ZXingScannerView.ios.cs
+++ b/ZXing.Net.Mobile/iOS/ZXingScannerView.ios.cs
@@ -620,7 +620,7 @@ namespace ZXing.Mobile
 				{
 					device.LockForConfiguration(out var err);
 
-					if (err != null)
+					if (err == null)
 					{
 						if (on)
 						{


### PR DESCRIPTION
Null check of `out` parameter `err` should be `if (err == null)` rather than `if (err != null)`. 

Otherwise `device.TorchMode` is generally unreachable.

Amending it as per the pull request fixes `viewController?.ToggleTorch()` which previously wasn't working in iOS.