### PR TITLE
ZXingScannerViewRenderer was causing the app to crash if the view was inside a ContentView

### DIFF
--- a/ZXing.Net.Mobile.Forms/ZXingScannerViewRenderer.android.cs
+++ b/ZXing.Net.Mobile.Forms/ZXingScannerViewRenderer.android.cs
@@ -73,7 +73,7 @@ namespace ZXing.Net.Mobile.Forms.Android
 					}
 				}
 
-				zxingSurface = new ZXingSurfaceView(Context as Activity, formsView.Options);
+				zxingSurface = new ZXingSurfaceView(Context, formsView.Options);
 				zxingSurface.LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
 
 				base.SetNativeControl(zxingSurface);


### PR DESCRIPTION
If the `ZXingScannerView` was inside of a `ContentView` instead of a `ContentPage`, the application would crash by throwing a `Java.Lang.NullPointerException`. The `Context` passed to `ZXingScannerViewRenderer` via the constructor was actually a `ContextThemeWrapper` which does not inherit from `Activity`. Therefore when it was cast in the call of the constructor of `ZXingScannerView` in the renderer on Android, a `null` would be passed for a context instead.

Fixes: #943